### PR TITLE
Add shapefile parser and metadata extraction (#26)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -14,3 +14,11 @@ uploads/*
 !uploads/.gitkeep
 outputs/*
 !outputs/.gitkeep
+
+# Generated test shapefiles (run scripts/generate_test_shapefile.py to create)
+resources/*.shp
+resources/*.shx
+resources/*.dbf
+resources/*.prj
+resources/*.cpg
+resources/*.zip

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     # Allowed geospatial file extensions (lowercase)
     ALLOWED_EXTENSIONS: List[str] = [
         ".shp",
+        ".zip",  # Shapefile as zip (.shp + .shx, .dbf, .prj)
         ".geojson",
         ".json",  # GeoJSON often has .json
         ".kml",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.24.0
 python-multipart>=0.0.6
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
+geopandas>=0.14.0

--- a/backend/resources/README.md
+++ b/backend/resources/README.md
@@ -1,0 +1,104 @@
+# Test / resource files
+
+Sample geospatial files for manual testing and automated tests.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `sample.geojson` | Small GeoJSON: 2 points + 1 polygon (San Francisco area). Use for upload and GeoJSON parsing tests. |
+| `parks.*` | Shapefile set (after generation): `parks.shp`, `.shx`, `.dbf`, `.prj`. Use for shapefile parser and zip-upload tests. |
+
+## Generating the test shapefile
+
+From the **project root** (or `backend/`), run:
+
+```bash
+cd backend
+python scripts/generate_test_shapefile.py
+```
+
+This writes `resources/parks.shp` (and sidecars). To test zip upload, zip the contents of `resources/` (or just `parks.shp`, `parks.shx`, `parks.dbf`, `parks.prj`) and `POST` to `/api/v1/upload`.
+
+## How to test #26 (Shapefile parser & metadata)
+
+### 1. Start the backend
+
+From project root:
+
+```bash
+cd backend
+python -m venv venv
+venv\Scripts\activate          # Windows
+# source venv/bin/activate    # macOS/Linux
+pip install -r requirements.txt
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Or with Docker: `docker compose up --build` (from project root).
+
+### 2. Generate the test shapefile
+
+In another terminal:
+
+```bash
+cd backend
+python scripts/generate_test_shapefile.py
+```
+
+You should see `resources/parks.shp` (and .shx, .dbf, .prj).
+
+### 3. Zip the shapefile
+
+Zip **only** the shapefile set (so the .shp is at the root of the zip):
+
+- **Windows (PowerShell):**  
+  `Compress-Archive -Path resources\parks.shp, resources\parks.shx, resources\parks.dbf, resources\parks.prj -DestinationPath resources\parks.zip`
+- **macOS/Linux:**  
+  `cd backend/resources && zip parks.zip parks.shp parks.shx parks.dbf parks.prj`
+
+### 4. Upload and check metadata
+
+**PowerShell:**
+
+```powershell
+$zip = Get-Item "backend\resources\parks.zip"
+Invoke-RestMethod -Uri "http://localhost:8000/api/v1/upload" -Method Post -Form @{ file = $zip }
+```
+
+**curl:**
+
+```bash
+curl -X POST http://localhost:8000/api/v1/upload -F "file=@backend/resources/parks.zip"
+```
+
+**Expected response:** `200 OK` with JSON like:
+
+```json
+{
+  "dataset_id": "some-uuid",
+  "filename": "parks.zip",
+  "feature_count": 3,
+  "geometry_type": "Polygon",
+  "crs": "EPSG:4326",
+  "bounds": [-122.44, 37.76, -122.41, 37.79]
+}
+```
+
+If `feature_count` is 3, `geometry_type` is `Polygon`, and `bounds` is set, the shapefile parser (#26) is working.
+
+### 5. Optional: single .shp upload
+
+Upload only `parks.shp` (no zip). The file is stored but metadata will be `feature_count: 0`, `geometry_type: null`, etc., because .shx/.dbf are required to read the shapefile. This confirms graceful fallback when sidecars are missing.
+
+---
+
+## Usage in tests
+
+Reference paths relative to the backend package, e.g.:
+
+```python
+from pathlib import Path
+RESOURCES = Path(__file__).resolve().parent.parent / "resources"
+sample_geojson = RESOURCES / "sample.geojson"
+```

--- a/backend/resources/sample.geojson
+++ b/backend/resources/sample.geojson
@@ -1,0 +1,44 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-122.4194, 37.7749]
+      },
+      "properties": {
+        "name": "Sample Point 1",
+        "id": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-122.42, 37.78]
+      },
+      "properties": {
+        "name": "Sample Point 2",
+        "id": 2
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-122.43, 37.77],
+          [-122.41, 37.77],
+          [-122.41, 37.79],
+          [-122.43, 37.79],
+          [-122.43, 37.77]
+        ]]
+      },
+      "properties": {
+        "name": "Sample Polygon",
+        "id": 3
+      }
+    }
+  ]
+}

--- a/backend/scripts/generate_test_shapefile.py
+++ b/backend/scripts/generate_test_shapefile.py
@@ -1,0 +1,41 @@
+"""
+Generate a minimal shapefile in backend/resources/ for testing.
+
+Run from backend directory:
+    python scripts/generate_test_shapefile.py
+
+Creates: resources/parks.shp, parks.shx, parks.dbf, parks.prj
+"""
+from pathlib import Path
+
+try:
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+except ImportError as e:
+    print("Requires geopandas and shapely. Install with: pip install geopandas")
+    raise SystemExit(1) from e
+
+RESOURCES = Path(__file__).resolve().parent.parent / "resources"
+RESOURCES.mkdir(parents=True, exist_ok=True)
+OUT_PATH = RESOURCES / "parks.shp"
+
+
+def main():
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["Park A", "Park B", "Park C"],
+            "area_ha": [1.2, 0.8, 2.1],
+        },
+        geometry=[
+            Polygon([(-122.43, 37.77), (-122.41, 37.77), (-122.41, 37.79), (-122.43, 37.79), (-122.43, 37.77)]),
+            Polygon([(-122.42, 37.774), (-122.41, 37.774), (-122.41, 37.776), (-122.42, 37.776), (-122.42, 37.774)]),
+            Polygon([(-122.44, 37.76), (-122.42, 37.76), (-122.42, 37.78), (-122.44, 37.78), (-122.44, 37.76)]),
+        ],
+        crs="EPSG:4326",
+    )
+    gdf.to_file(OUT_PATH)
+    print(f"Wrote {OUT_PATH} and sidecars to {RESOURCES}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -1,6 +1,7 @@
 """File I/O operations for uploads and outputs."""
 import shutil
 import uuid
+import zipfile
 from pathlib import Path
 from typing import BinaryIO
 
@@ -24,6 +25,23 @@ def save_upload(file: BinaryIO, filename: str) -> str:
 def get_upload_path(dataset_id: str) -> Path:
     """Return the directory path for a given dataset_id."""
     return settings.upload_path / dataset_id
+
+
+def extract_zip_in_upload_dir(dataset_id: str) -> bool:
+    """
+    If the dataset directory contains a single .zip file, extract it in place.
+    Returns True if a zip was extracted, False otherwise.
+    """
+    dest_dir = get_upload_path(dataset_id)
+    zips = list(dest_dir.glob("*.zip"))
+    if not zips or len(zips) > 1:
+        return False
+    try:
+        with zipfile.ZipFile(zips[0], "r") as zf:
+            zf.extractall(dest_dir)
+        return True
+    except (zipfile.BadZipFile, OSError):
+        return False
 
 
 def _sanitize_filename(name: str) -> str:

--- a/backend/services/shapefile_parser.py
+++ b/backend/services/shapefile_parser.py
@@ -1,0 +1,67 @@
+"""Shapefile parsing and metadata extraction using GeoPandas."""
+from pathlib import Path
+from typing import Optional
+
+import geopandas as gpd
+
+
+def parse_shapefile_metadata(directory: Path) -> Optional[dict]:
+    """
+    Parse a shapefile in the given directory and return metadata.
+
+    Expects at least one .shp file in the directory, with .shx and .dbf
+    sidecar files in the same folder (standard shapefile requirement).
+
+    Returns:
+        Dict with keys: feature_count, geometry_type, crs, bounds.
+        bounds is [minx, miny, maxx, maxy] or None.
+        Returns None if no .shp found or read fails (e.g. missing sidecars).
+    """
+    directory = Path(directory).resolve()
+    if not directory.is_dir():
+        return None
+
+    shp_files = list(directory.glob("*.shp"))
+    if not shp_files:
+        return None
+
+    shp_path = shp_files[0]
+    try:
+        gdf = gpd.read_file(shp_path)
+    except Exception:
+        return None
+
+    feature_count = len(gdf)
+    if gdf.empty or gdf.geometry is None:
+        return {
+            "feature_count": 0,
+            "geometry_type": None,
+            "crs": _crs_to_string(gdf.crs) if gdf.crs is not None else None,
+            "bounds": None,
+        }
+
+    geom_types = gdf.geometry.geom_type.dropna().unique()
+    geometry_type = geom_types[0] if len(geom_types) == 1 else ",".join(sorted(geom_types))
+    crs = _crs_to_string(gdf.crs)
+    try:
+        tb = gdf.total_bounds
+        bounds = tb.tolist() if tb is not None and len(tb) == 4 else None
+    except Exception:
+        bounds = None
+
+    return {
+        "feature_count": feature_count,
+        "geometry_type": geometry_type,
+        "crs": crs,
+        "bounds": bounds,
+    }
+
+
+def _crs_to_string(crs) -> Optional[str]:
+    """Convert a pyproj/CRS object to a string (e.g. EPSG:4326)."""
+    if crs is None:
+        return None
+    try:
+        return crs.to_string() if hasattr(crs, "to_string") else str(crs)
+    except Exception:
+        return str(crs)


### PR DESCRIPTION
## Summary
Implements **#26** (Shapefile parser and metadata extraction): parse shapefiles with GeoPandas, extract feature count, geometry type, CRS, and bounds, and return them in the upload API response. Also supports uploading shapefiles as a single `.zip` (extract then parse).

## Changes

### Shapefile parser
- **`backend/services/shapefile_parser.py`** (new)
  - `parse_shapefile_metadata(directory)` finds a `.shp` in the directory, reads with GeoPandas, returns `feature_count`, `geometry_type`, `crs`, `bounds` `[minx, miny, maxx, maxy]`.
  - Returns `None` when no `.shp` or read fails (e.g. missing .shx/.dbf); upload still succeeds with placeholder metadata.

### Upload flow
- **`backend/api/routes.py`**
  - After saving the file: if upload is `.zip`, extract to dataset directory; if `.shp` or `.zip`, run shapefile parser and fill `UploadResponse` with real metadata when parsing succeeds.

### File handling
- **`backend/services/file_handler.py`**
  - `extract_zip_in_upload_dir(dataset_id)` extracts a single `.zip` in the dataset folder so shapefile components are available for parsing.

### Config & dependencies
- **`backend/core/config.py`**: added `.zip` to `ALLOWED_EXTENSIONS`.
- **`backend/requirements.txt`**: added `geopandas>=0.14.0`.

### Test resources
- **`backend/resources/`**
  - `sample.geojson` — small GeoJSON for upload tests.
  - `README.md` — describes test files and **how to test #26** (generate shapefile, zip, upload, check response).
- **`backend/scripts/generate_test_shapefile.py`** — generates `resources/parks.shp` (+ sidecars) for shapefile/zip testing.
- **`backend/.gitignore`** — ignore generated shapefile and zip artifacts in `resources/`.

## Testing
- Generate shapefile: `cd backend && python scripts/generate_test_shapefile.py`
- Zip `parks.shp`, `.shx`, `.dbf`, `.prj` → `parks.zip`
- `POST /api/v1/upload` with `parks.zip` → response includes `feature_count: 3`, `geometry_type: "Polygon"`, `crs: "EPSG:4326"`, `bounds: [...]`
- See `backend/resources/README.md` for full steps.

## Related
- Closes #26
- Part of #2 (File ingestion); follow-up: #27 GeoJSON parser, #28 unified response/error handling.