### PR TITLE
Add GeoJSON parser and metadata extraction (#27)

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -7,9 +7,11 @@ from api.models import UploadResponse
 from core.config import settings
 from services.file_handler import (
     extract_zip_in_upload_dir,
+    get_saved_file_path,
     get_upload_path,
     save_upload,
 )
+from services.geojson_parser import parse_geojson_metadata
 from services.shapefile_parser import parse_shapefile_metadata
 
 router = APIRouter()
@@ -69,6 +71,14 @@ async def upload_dataset(file: UploadFile = File(..., description="Shapefile, Ge
     if suffix in (".shp", ".zip"):
         upload_dir = get_upload_path(dataset_id)
         meta = parse_shapefile_metadata(upload_dir)
+        if meta:
+            feature_count = meta["feature_count"]
+            geometry_type = meta["geometry_type"]
+            crs = meta["crs"]
+            bounds = meta["bounds"]
+    elif suffix in (".geojson", ".json"):
+        saved_path = get_saved_file_path(dataset_id, file.filename)
+        meta = parse_geojson_metadata(saved_path)
         if meta:
             feature_count = meta["feature_count"]
             geometry_type = meta["geometry_type"]

--- a/backend/resources/README.md
+++ b/backend/resources/README.md
@@ -91,6 +91,14 @@ If `feature_count` is 3, `geometry_type` is `Polygon`, and `bounds` is set, the 
 
 Upload only `parks.shp` (no zip). The file is stored but metadata will be `feature_count: 0`, `geometry_type: null`, etc., because .shx/.dbf are required to read the shapefile. This confirms graceful fallback when sidecars are missing.
 
+## How to test #27 (GeoJSON parser & metadata)
+
+1. Start the backend (same as above).
+2. Upload the sample GeoJSON:
+   - **PowerShell:** `Invoke-RestMethod -Uri "http://localhost:8000/api/v1/upload" -Method Post -Form @{ file = Get-Item "backend\resources\sample.geojson" }`
+   - **curl:** `curl -X POST http://localhost:8000/api/v1/upload -F "file=@backend/resources/sample.geojson"`
+3. **Expected response:** `feature_count: 3`, `geometry_type` (e.g. `Point` or mixed), `bounds` set. Standard GeoJSON is WGS84, so `crs` may be `EPSG:4326` or similar.
+
 ---
 
 ## Usage in tests

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -27,6 +27,11 @@ def get_upload_path(dataset_id: str) -> Path:
     return settings.upload_path / dataset_id
 
 
+def get_saved_file_path(dataset_id: str, filename: str) -> Path:
+    """Return the path where an uploaded file was saved (sanitized filename)."""
+    return get_upload_path(dataset_id) / _sanitize_filename(filename)
+
+
 def extract_zip_in_upload_dir(dataset_id: str) -> bool:
     """
     If the dataset directory contains a single .zip file, extract it in place.

--- a/backend/services/geojson_parser.py
+++ b/backend/services/geojson_parser.py
@@ -1,0 +1,59 @@
+"""GeoJSON parsing and metadata extraction using GeoPandas."""
+from pathlib import Path
+from typing import Optional
+
+import geopandas as gpd
+
+
+def parse_geojson_metadata(path: Path) -> Optional[dict]:
+    """
+    Parse a GeoJSON file and return metadata.
+
+    Returns:
+        Dict with keys: feature_count, geometry_type, crs, bounds.
+        bounds is [minx, miny, maxx, maxy] or None.
+        Returns None if path is not a file, read fails, or content is not valid GeoJSON.
+    """
+    path = Path(path).resolve()
+    if not path.is_file():
+        return None
+
+    try:
+        gdf = gpd.read_file(path)
+    except Exception:
+        return None
+
+    feature_count = len(gdf)
+    if gdf.empty or gdf.geometry is None:
+        return {
+            "feature_count": 0,
+            "geometry_type": None,
+            "crs": _crs_to_string(gdf.crs) if gdf.crs is not None else None,
+            "bounds": None,
+        }
+
+    geom_types = gdf.geometry.geom_type.dropna().unique()
+    geometry_type = geom_types[0] if len(geom_types) == 1 else ",".join(sorted(geom_types))
+    crs = _crs_to_string(gdf.crs)
+    try:
+        tb = gdf.total_bounds
+        bounds = tb.tolist() if tb is not None and len(tb) == 4 else None
+    except Exception:
+        bounds = None
+
+    return {
+        "feature_count": feature_count,
+        "geometry_type": geometry_type,
+        "crs": crs,
+        "bounds": bounds,
+    }
+
+
+def _crs_to_string(crs) -> Optional[str]:
+    """Convert a pyproj/CRS object to a string (e.g. EPSG:4326)."""
+    if crs is None:
+        return None
+    try:
+        return crs.to_string() if hasattr(crs, "to_string") else str(crs)
+    except Exception:
+        return str(crs)


### PR DESCRIPTION
## Summary
Implements **#27** (GeoJSON parser and metadata extraction): parse GeoJSON files with GeoPandas, extract feature count, geometry type, CRS, and bounds, and return them in the upload API response for `.geojson` and `.json` uploads.

## Changes

### GeoJSON parser
- **`backend/services/geojson_parser.py`** (new)
  - `parse_geojson_metadata(path)` reads a GeoJSON file at the given path, returns `feature_count`, `geometry_type`, `crs`, `bounds` `[minx, miny, maxx, maxy]`.
  - Returns `None` when the file is missing or not valid GeoJSON; upload still succeeds with placeholder metadata.

### Upload flow
- **`backend/api/routes.py`**
  - For uploads with suffix `.geojson` or `.json`, calls the GeoJSON parser on the saved file and fills `UploadResponse` with metadata when parsing succeeds.

### File handling
- **`backend/services/file_handler.py`**
  - `get_saved_file_path(dataset_id, filename)` returns the path where an uploaded file was saved (sanitized filename), so the route can pass it to the GeoJSON parser.

### Documentation
- **`backend/resources/README.md`**
  - Added **"How to test #27"** with steps to upload `sample.geojson` and verify the response.

## Testing
- Start backend, then upload `backend/resources/sample.geojson`.
- **Expected:** `200 OK` with `feature_count: 3`, `geometry_type` (e.g. mixed), `bounds` set. Standard GeoJSON is typically WGS84 (`EPSG:4326` or similar).

## Related
- Closes #27
- Part of #2 (File ingestion). Follow-up: #28 Unified response and error handling.