### PR TITLE
Unified ingestion response and error handling (#28)

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,22 +1,32 @@
 """Pydantic schemas for API request/response."""
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
 
+# Error codes for consistent API error responses
+class ErrorCode:
+    """Error codes returned in API error responses."""
+
+    NO_FILE = "NO_FILE"
+    INVALID_FILE_TYPE = "INVALID_FILE_TYPE"
+    FILE_TOO_LARGE = "FILE_TOO_LARGE"
+    SAVE_FAILED = "SAVE_FAILED"
+
+
 class UploadResponse(BaseModel):
-    """Response after successful dataset upload."""
+    """Unified response after successful dataset upload. All upload endpoints return this schema."""
 
     dataset_id: str = Field(..., description="Unique identifier for the uploaded dataset")
     filename: str = Field(..., description="Original filename")
-    feature_count: int = Field(0, description="Number of features (0 until parsed)")
+    feature_count: int = Field(0, description="Number of features (0 if not parsed)")
     geometry_type: Optional[str] = Field(None, description="Geometry type e.g. Polygon, Point")
     crs: Optional[str] = Field(None, description="Coordinate reference system e.g. EPSG:4326")
     bounds: Optional[List[float]] = Field(None, description="[minX, minY, maxX, maxY]")
 
 
 class ErrorResponse(BaseModel):
-    """Standard error response."""
+    """Standard error response for failed requests."""
 
-    detail: str = Field(..., description="Error message")
-    code: Optional[str] = Field(None, description="Optional error code")
+    detail: str = Field(..., description="Human-readable error message")
+    code: Optional[str] = Field(None, description="Machine-readable error code")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ python-multipart>=0.0.6
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
 geopandas>=0.14.0
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+httpx>=0.24.0

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest fixtures for API and service tests."""
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure backend root is on path when running tests from project root
+import sys
+_backend = Path(__file__).resolve().parent.parent
+if str(_backend) not in sys.path:
+    sys.path.insert(0, str(_backend))
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    """FastAPI test client."""
+    return TestClient(app)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,57 @@
+"""Tests for API upload route and error handling."""
+from pathlib import Path
+
+import pytest
+from api.models import ErrorCode
+
+
+def test_health(client):
+    """Health endpoint returns ok."""
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_upload_no_file(client):
+    """Upload with empty filename returns 400 with NO_FILE code."""
+    # Send file with empty filename to trigger "No file provided"
+    r = client.post("/api/v1/upload", files={"file": ("", b"content")})
+    assert r.status_code == 400
+    data = r.json()
+    assert data.get("code") == ErrorCode.NO_FILE
+    assert "detail" in data
+
+
+def test_upload_invalid_file_type(client):
+    """Upload with disallowed extension returns 400 with INVALID_FILE_TYPE."""
+    path = Path(__file__).parent.parent / "resources" / "sample.geojson"
+    if not path.exists():
+        pytest.skip("sample.geojson not found")
+    # Send with wrong extension by using a different filename
+    r = client.post(
+        "/api/v1/upload",
+        files={"file": ("bad.pdf", path.read_bytes(), "application/pdf")},
+    )
+    assert r.status_code == 400
+    data = r.json()
+    assert data.get("code") == ErrorCode.INVALID_FILE_TYPE
+    assert "Allowed extensions" in data.get("detail", "")
+
+
+def test_upload_success_geojson(client):
+    """Upload valid GeoJSON returns 200 and unified UploadResponse."""
+    path = Path(__file__).parent.parent / "resources" / "sample.geojson"
+    if not path.exists():
+        pytest.skip("sample.geojson not found")
+    r = client.post(
+        "/api/v1/upload",
+        files={"file": ("sample.geojson", path.read_bytes(), "application/geo+json")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "dataset_id" in data
+    assert data["filename"] == "sample.geojson"
+    assert data["feature_count"] >= 0
+    assert "geometry_type" in data
+    assert "crs" in data or data["crs"] is None
+    assert "bounds" in data or data["bounds"] is None

--- a/backend/tests/test_file_handler.py
+++ b/backend/tests/test_file_handler.py
@@ -1,0 +1,71 @@
+"""Tests for services.file_handler."""
+import io
+from pathlib import Path
+
+import pytest
+
+# Backend on path via conftest
+from services.file_handler import (
+    _sanitize_filename,
+    extract_zip_in_upload_dir,
+    get_saved_file_path,
+    get_upload_path,
+    save_upload,
+)
+
+
+def test_sanitize_filename():
+    """Sanitize keeps alphanumeric and ._- space."""
+    assert _sanitize_filename("valid.geojson") == "valid.geojson"
+    assert _sanitize_filename("  parks.shp  ") == "parks.shp"
+    assert _sanitize_filename("file with spaces.json") == "file with spaces.json"
+    # Strip path-like or unsafe
+    safe = _sanitize_filename("../../etc/passwd")
+    assert ".." not in safe and "/" not in safe
+
+
+def test_save_upload_returns_uuid(tmp_path, monkeypatch):
+    """save_upload creates dataset dir and returns a UUID string."""
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    content = io.BytesIO(b"test content")
+    dataset_id = save_upload(content, "test.geojson")
+    assert dataset_id
+    assert len(dataset_id) == 36  # UUID format
+    dest_dir = tmp_path / dataset_id
+    assert dest_dir.is_dir()
+    assert (dest_dir / "test.geojson").read_bytes() == b"test content"
+
+
+def test_get_upload_path():
+    """get_upload_path returns path under upload_path."""
+    path = get_upload_path("some-uuid")
+    assert "some-uuid" in str(path)
+
+
+def test_get_saved_file_path():
+    """get_saved_file_path combines dataset dir and sanitized filename."""
+    path = get_saved_file_path("abc-123", "my file.geojson")
+    assert path.name == "my file.geojson"
+    assert "abc-123" in str(path)
+
+
+def test_extract_zip_in_upload_dir_no_zip(tmp_path, monkeypatch):
+    """extract_zip_in_upload_dir returns False when no zip in dir."""
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    dataset_id = "no-zip-dataset"
+    (tmp_path / dataset_id).mkdir()
+    assert extract_zip_in_upload_dir(dataset_id) is False
+
+
+def test_extract_zip_in_upload_dir_with_zip(tmp_path, monkeypatch):
+    """extract_zip_in_upload_dir extracts when single zip present."""
+    import zipfile
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    dataset_id = "zip-dataset"
+    dest_dir = tmp_path / dataset_id
+    dest_dir.mkdir()
+    zip_path = dest_dir / "data.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("inside.txt", "hello")
+    assert extract_zip_in_upload_dir(dataset_id) is True
+    assert (dest_dir / "inside.txt").read_text() == "hello"


### PR DESCRIPTION
## Summary
Implements **#28** (Unified ingestion response and error handling): one response schema for uploads, consistent error messages with machine-readable codes, and tests for the file handler and upload route.

## Changes

### Unified response and error codes
- **`backend/api/models.py`**
  - **`ErrorCode`** — constants: `NO_FILE`, `INVALID_FILE_TYPE`, `FILE_TOO_LARGE`, `SAVE_FAILED`.
  - **`UploadResponse`** — docstring updated to state it is the single upload response schema.
  - **`ErrorResponse`** — docstring clarified; used for documented error responses.

### Error handling in upload route
- **`backend/api/routes.py`**
  - All upload errors return a JSON body with `detail` (message) and `code` (e.g. `ErrorCode.INVALID_FILE_TYPE`).
  - **400** — No file: `"No file provided. Send a file in the 'file' form field."` + `NO_FILE`.
  - **400** — Invalid type: `"File type not allowed. Allowed extensions: ..."` + `INVALID_FILE_TYPE`.
  - **413** — Too large: `"File too large. Maximum size is {n} MB."` + `FILE_TOO_LARGE`.
  - **500** — Save failed: error message + `SAVE_FAILED`.
  - OpenAPI `responses` for 400, 413, 500 reference **`ErrorResponse`** so the error schema is documented.

### Tests
- **`backend/tests/conftest.py`** — Adds backend to path when needed; **`client`** fixture (FastAPI `TestClient`).
- **`backend/tests/test_file_handler.py`** — `_sanitize_filename`, `save_upload`, `get_upload_path`, `get_saved_file_path`, `extract_zip_in_upload_dir` (no zip / with zip).
- **`backend/tests/test_api.py`** — `/health`, upload with no file (400 + `NO_FILE`), invalid file type (400 + `INVALID_FILE_TYPE`), successful GeoJSON upload (200 + unified `UploadResponse`).
- **`backend/requirements.txt`** — Added `pytest`, `pytest-asyncio`, `httpx` for tests.

## Testing
From backend directory:
```bash
pip install -r requirements.txt
pytest tests/ -v
```

## Related
- Closes #28
- Completes Phase 1 file ingestion tasks (#25, #26, #27, #28) for parent #2.