### PR TITLE
feat(#31): Geometry validation API integration

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -22,6 +22,7 @@ class ErrorCode:
     INVALID_FILE_TYPE = "INVALID_FILE_TYPE"
     FILE_TOO_LARGE = "FILE_TOO_LARGE"
     SAVE_FAILED = "SAVE_FAILED"
+    DATASET_NOT_FOUND = "DATASET_NOT_FOUND"
 
 
 class UploadResponse(BaseModel):
@@ -33,6 +34,19 @@ class UploadResponse(BaseModel):
     geometry_type: Optional[str] = Field(None, description="Geometry type e.g. Polygon, Point")
     crs: Optional[str] = Field(None, description="Coordinate reference system e.g. EPSG:4326")
     bounds: Optional[List[float]] = Field(None, description="[minX, minY, maxX, maxY]")
+
+
+class ValidationResult(BaseModel):
+    """Result of geometry validation for a dataset."""
+
+    dataset_id: str = Field(..., description="Dataset identifier that was validated")
+    issues: List[GeometryIssue] = Field(default_factory=list, description="List of geometry issues found")
+
+
+class ValidateRequest(BaseModel):
+    """Request body for POST /validate."""
+
+    dataset_id: str = Field(..., description="Dataset identifier (from upload) to validate")
 
 
 class ErrorResponse(BaseModel):

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -27,6 +27,10 @@ class Settings(BaseSettings):
     UPLOAD_DIR: str = "./uploads"
     OUTPUT_DIR: str = "./outputs"
 
+    # Geometry validation (POST/GET /validate): all checks enabled by default
+    # Checks: null/empty geometry, invalid geometry, self-intersection (see core.validation)
+    GEOMETRY_VALIDATION_ENABLED: bool = True
+
     # Allowed geospatial file extensions (lowercase)
     ALLOWED_EXTENSIONS: List[str] = [
         ".shp",

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -3,7 +3,7 @@ import shutil
 import uuid
 import zipfile
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, Optional
 
 from core.config import settings
 
@@ -30,6 +30,23 @@ def get_upload_path(dataset_id: str) -> Path:
 def get_saved_file_path(dataset_id: str, filename: str) -> Path:
     """Return the path where an uploaded file was saved (sanitized filename)."""
     return get_upload_path(dataset_id) / _sanitize_filename(filename)
+
+
+def get_primary_vector_path(dataset_id: str) -> Optional[Path]:
+    """
+    Return the path to the primary vector file for a dataset (for GeoPandas read_file).
+    Prefers .geojson, then .json, then .shp. Returns None if dataset dir does not exist
+    or contains no supported vector file.
+    """
+    dest_dir = get_upload_path(dataset_id)
+    if not dest_dir.is_dir():
+        return None
+    # Order: GeoJSON first, then shapefile
+    for ext in (".geojson", ".json", ".shp"):
+        candidates = list(dest_dir.glob(f"*{ext}"))
+        if candidates:
+            return candidates[0]
+    return None
 
 
 def extract_zip_in_upload_dir(dataset_id: str) -> bool:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,4 +1,4 @@
-"""Tests for API upload route and error handling."""
+"""Tests for API upload route, validate route, and error handling."""
 from pathlib import Path
 
 import pytest
@@ -61,3 +61,61 @@ def test_upload_success_geojson(client):
     assert "geometry_type" in data
     assert "crs" in data or data["crs"] is None
     assert "bounds" in data or data["bounds"] is None
+
+
+def test_validate_dataset_not_found(client):
+    """POST /validate with unknown dataset_id returns 404 with DATASET_NOT_FOUND."""
+    r = client.post("/api/v1/validate", json={"dataset_id": "00000000-0000-0000-0000-000000000000"})
+    assert r.status_code == 404
+    detail = r.json().get("detail")
+    code = detail.get("code") if isinstance(detail, dict) else r.json().get("code")
+    assert code == ErrorCode.DATASET_NOT_FOUND
+
+
+def test_get_validation_not_found(client):
+    """GET /validate/{dataset_id} with unknown dataset_id returns 404."""
+    r = client.get("/api/v1/validate/00000000-0000-0000-0000-000000000000")
+    assert r.status_code == 404
+    detail = r.json().get("detail")
+    code = detail.get("code") if isinstance(detail, dict) else r.json().get("code")
+    assert code == ErrorCode.DATASET_NOT_FOUND
+
+
+def test_post_validate_success(client):
+    """POST /validate with valid dataset_id returns ValidationResult with issues list."""
+    path = Path(__file__).parent.parent / "resources" / "sample.geojson"
+    if not path.exists():
+        pytest.skip("sample.geojson not found")
+    upload = client.post(
+        "/api/v1/upload",
+        files={"file": ("sample.geojson", path.read_bytes(), "application/geo+json")},
+    )
+    assert upload.status_code == 200
+    dataset_id = upload.json()["dataset_id"]
+    r = client.post("/api/v1/validate", json={"dataset_id": dataset_id})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["dataset_id"] == dataset_id
+    assert "issues" in data
+    assert isinstance(data["issues"], list)
+    for issue in data["issues"]:
+        assert "feature_id" in issue and "type" in issue and "severity" in issue
+
+
+def test_get_validate_success(client):
+    """GET /validate/{dataset_id} returns same ValidationResult shape."""
+    path = Path(__file__).parent.parent / "resources" / "sample.geojson"
+    if not path.exists():
+        pytest.skip("sample.geojson not found")
+    upload = client.post(
+        "/api/v1/upload",
+        files={"file": ("sample.geojson", path.read_bytes(), "application/geo+json")},
+    )
+    assert upload.status_code == 200
+    dataset_id = upload.json()["dataset_id"]
+    r = client.get(f"/api/v1/validate/{dataset_id}")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["dataset_id"] == dataset_id
+    assert "issues" in data
+    assert isinstance(data["issues"], list)

--- a/backend/tests/test_file_handler.py
+++ b/backend/tests/test_file_handler.py
@@ -8,6 +8,7 @@ import pytest
 from services.file_handler import (
     _sanitize_filename,
     extract_zip_in_upload_dir,
+    get_primary_vector_path,
     get_saved_file_path,
     get_upload_path,
     save_upload,
@@ -69,3 +70,21 @@ def test_extract_zip_in_upload_dir_with_zip(tmp_path, monkeypatch):
         zf.writestr("inside.txt", "hello")
     assert extract_zip_in_upload_dir(dataset_id) is True
     assert (dest_dir / "inside.txt").read_text() == "hello"
+
+
+def test_get_primary_vector_path_missing(tmp_path, monkeypatch):
+    """get_primary_vector_path returns None when dataset dir does not exist."""
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    assert get_primary_vector_path("nonexistent-id") is None
+
+
+def test_get_primary_vector_path_geojson(tmp_path, monkeypatch):
+    """get_primary_vector_path returns path to .geojson when present."""
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    dataset_id = "geo-dataset"
+    dest_dir = tmp_path / dataset_id
+    dest_dir.mkdir()
+    (dest_dir / "data.geojson").write_text("{}")
+    path = get_primary_vector_path(dataset_id)
+    assert path is not None
+    assert path.name == "data.geojson"


### PR DESCRIPTION
## Summary
Implements **issue #31** (Geometry validation API integration) for the Basic geometry validation epic (#3). Wires the existing geometry validation logic into REST endpoints and returns issues in the correct schema.

## Changes

### API models (`backend/api/models.py`)
- **`ValidationResult`**: `dataset_id` + `issues: List[GeometryIssue]` for validate responses
- **`ValidateRequest`**: request body for POST /validate with `dataset_id`
- **`ErrorCode.DATASET_NOT_FOUND`**: used when dataset or vector file is missing (404)

### File handler (`backend/services/file_handler.py`)
- **`get_primary_vector_path(dataset_id)`**: returns path to the primary vector file for a dataset (prefers .geojson → .json → .shp), or `None` if not found

### Routes (`backend/api/routes.py`)
- **POST `/api/v1/validate`**: body `{ "dataset_id": "uuid" }` → runs geometry validation, returns `ValidationResult` with issues (correct schema: feature_id, type, severity, location, description)
- **GET `/api/v1/validate/{dataset_id}`**: same validation and response shape
- 404 with `DATASET_NOT_FOUND` when dataset does not exist or has no supported vector file

### Config (`backend/core/config.py`)
- **`GEOMETRY_VALIDATION_ENABLED`** (default `True`) and comment documenting enabled checks: null/empty geometry, invalid geometry, self-intersection (see `core.validation`)

### Tests
- **`tests/test_api.py`**: `test_validate_dataset_not_found`, `test_get_validation_not_found`, `test_post_validate_success`, `test_get_validate_success`
- **`tests/test_file_handler.py`**: `test_get_primary_vector_path_missing`, `test_get_primary_vector_path_geojson`

## Related
- Closes #31
- Builds on geometry validation logic and agent from PR #42 (issues #29, #30)

## How to test
```bash
cd backend && python -m pytest tests/ -v --tb=short
```