### PR TITLE
feat(#34): map zoom/pan and layer visibility

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,8 +1,8 @@
 # Backend API (for proxy)
 VITE_API_BASE_URL=http://localhost:8000
 
-# ArcGIS Maps SDK for JavaScript (required for basemaps and many services)
-# Get a key: https://developers.arcgis.com/
+# ArcGIS Maps SDK for JavaScript — required for the map (basemaps, tiles, GeoJSON layer)
+# Get a free key: https://developers.arcgis.com/
 VITE_ARCGIS_API_KEY=your_arcgis_api_key_here
 
 # Map initial center and zoom (configurable)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,14 +1,16 @@
 # Frontend — GeoSpatial Data Quality Agent
 
-React + TypeScript + Vite app with ArcGIS MapView for map-based preview (Issue #32).
+React + TypeScript + Vite app with ArcGIS MapView for map-based preview. The map supports zoom/pan (mouse + Zoom widget) and a layer visibility toggle for the uploaded dataset (Issue #32, #34).
 
 ## Setup
 
 ```bash
 npm install
 cp .env.example .env
-# Edit .env and set VITE_ARCGIS_API_KEY (get one at https://developers.arcgis.com/)
+# Edit .env and set VITE_ARCGIS_API_KEY (required for the map — see below)
 ```
+
+**ArcGIS API key (required):** The map uses the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/) for basemaps and tiles. You must set `VITE_ARCGIS_API_KEY` in `.env`; get a free key at [https://developers.arcgis.com/](https://developers.arcgis.com/).
 
 ## Configurable map (env)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -93,6 +93,7 @@ function App() {
         <MapViewer
           datasetId={currentDataset?.dataset_id}
           bounds={currentDataset?.bounds ?? null}
+          layerTitle={currentDataset?.filename}
         />
       </main>
     </div>

--- a/frontend/src/components/Map/MapViewer.tsx
+++ b/frontend/src/components/Map/MapViewer.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import esriConfig from "@arcgis/core/config.js";
 import Map from "@arcgis/core/Map.js";
 import MapView from "@arcgis/core/views/MapView.js";
 import GeoJSONLayer from "@arcgis/core/layers/GeoJSONLayer.js";
 import Extent from "@arcgis/core/geometry/Extent.js";
+import Zoom from "@arcgis/core/widgets/Zoom.js";
 
 import { defaultCenter, defaultZoom } from "../../services/mapService";
 
@@ -14,18 +15,23 @@ if (apiKey) {
   esriConfig.apiKey = apiKey;
 }
 
+const DATASET_LAYER_ID = "dataset-layer";
+
 export type MapViewerProps = {
   datasetId?: string;
   bounds?: number[] | null;
+  /** Optional title for the dataset layer (e.g. filename) for the layer list. */
+  layerTitle?: string;
 };
 
-export function MapViewer({ datasetId, bounds }: MapViewerProps) {
+export function MapViewer({ datasetId, bounds, layerTitle }: MapViewerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
   const viewRef = useRef<MapView | null>(null);
   const layerRef = useRef<GeoJSONLayer | null>(null);
+  const [datasetLayerVisible, setDatasetLayerVisible] = useState(true);
 
-  // Initialize map and view once
+  // Initialize map and view once (zoom/pan enabled by default on MapView)
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -41,6 +47,9 @@ export function MapViewer({ datasetId, bounds }: MapViewerProps) {
       zoom: defaultZoom,
     });
     viewRef.current = view;
+
+    const zoom = new Zoom({ view, layout: "vertical" });
+    view.ui.add(zoom, "top-right");
 
     return () => {
       if (viewRef.current) {
@@ -72,7 +81,13 @@ export function MapViewer({ datasetId, bounds }: MapViewerProps) {
     }
 
     const url = `/api/v1/datasets/${datasetId}/geojson`;
-    const layer = new GeoJSONLayer({ url });
+    const layer = new GeoJSONLayer({
+      url,
+      id: DATASET_LAYER_ID,
+      title: layerTitle || "Dataset",
+    });
+    layer.visible = true;
+    setDatasetLayerVisible(true);
     map.add(layer);
     layerRef.current = layer;
 
@@ -97,14 +112,56 @@ export function MapViewer({ datasetId, bounds }: MapViewerProps) {
         }
       });
     }
-  }, [datasetId, bounds?.join(",")]);
+  }, [datasetId, bounds?.join(","), layerTitle]);
+
+  // Sync visibility toggle to layer when layer exists
+  useEffect(() => {
+    if (layerRef.current) {
+      layerRef.current.visible = datasetLayerVisible;
+    }
+  }, [datasetLayerVisible]);
+
+  const handleLayerVisibilityChange = () => {
+    setDatasetLayerVisible((v) => !v);
+  };
 
   return (
-    <div
-      ref={containerRef}
-      className="map-viewer"
-      style={{ width: "100%", height: "100%", minHeight: 400 }}
-      aria-label="Map view"
-    />
+    <div className="map-viewer-wrapper" style={{ position: "relative", width: "100%", height: "100%", minHeight: 400 }}>
+      {datasetId && (
+        <div
+          className="map-layer-list"
+          style={{
+            position: "absolute",
+            top: 8,
+            left: 8,
+            zIndex: 1,
+            background: "rgba(255,255,255,0.95)",
+            padding: "8px 12px",
+            borderRadius: 6,
+            boxShadow: "0 1px 4px rgba(0,0,0,0.2)",
+            fontSize: "0.875rem",
+          }}
+          role="group"
+          aria-label="Layers"
+        >
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>Layers</div>
+          <label style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={datasetLayerVisible}
+              onChange={handleLayerVisibilityChange}
+              aria-label="Toggle dataset layer visibility"
+            />
+            <span>{layerTitle || "Dataset"}</span>
+          </label>
+        </div>
+      )}
+      <div
+        ref={containerRef}
+        className="map-viewer"
+        style={{ width: "100%", height: "100%", minHeight: 400 }}
+        aria-label="Map view"
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Implements **issue #34**: Map zoom/pan and layer visibility (parent: epic #4 Map-based preview).

## Changes

### Zoom / pan
- **Zoom widget** added to the map (top-right) so users can zoom in/out via buttons. MapView already supports mouse wheel zoom and drag-to-pan; the widget makes zoom controls explicit and accessible.

### Layer list and visibility
- **Layer panel** (top-left) when a dataset is loaded:
  - "Layers" heading with a **visibility toggle** (checkbox) for the dataset layer.
  - Layer label uses the uploaded filename when available (`layerTitle` prop).
- New datasets load with the layer visible; toggling the checkbox shows/hides the dataset layer.

### Documentation
- **README.md**: Clarified that the ArcGIS API key is **required** for the map (basemaps, tiles); added a short section with link to get a key. Updated intro to mention zoom/pan and layer visibility.
- **.env.example**: Comment for `VITE_ARCGIS_API_KEY` updated to state it is required for the map (basemaps, tiles, GeoJSON layer).

## Files changed
- `frontend/src/components/Map/MapViewer.tsx` — Zoom widget, layer panel, visibility state/sync, `layerTitle` prop.
- `frontend/src/App.tsx` — Passes `layerTitle={currentDataset?.filename}` to MapViewer.
- `frontend/README.md` — API key requirement and map behavior.
- `frontend/.env.example` — API key comment.

## Checklist
- [x] Zoom/pan work (widget + default MapView behavior).
- [x] Optional layer list with visibility toggle.
- [x] ArcGIS API key requirement documented.

Closes #34