### PR TITLE
feat(#35): validation trigger and status display

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@arcgis/core": "^4.28.0",
+        "@esri/calcite-components-react": "^5.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -808,6 +809,83 @@
         "type-fest": "^4.30.1"
       }
     },
+    "node_modules/@esri/calcite-components-react": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-5.0.2.tgz",
+      "integrity": "sha512-UF6HdVQLd6w7ZqW5ma4KcT7iFru5IlWLDqfnsdH+PAwWQiJj0WZo/8i3cVVKGNgDh2cJdpXmbGdFOoGc7Ui7RA==",
+      "license": "SEE LICENSE.md",
+      "dependencies": {
+        "@arcgis/lumina": ">=5.0.0-next.144 <6.0.0",
+        "@esri/calcite-components": "5.0.2",
+        "@lit/react": "^1.0.8",
+        "lit": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.3",
+        "react-dom": ">=18.3"
+      }
+    },
+    "node_modules/@esri/calcite-components-react/node_modules/@arcgis/lumina": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-5.0.8.tgz",
+      "integrity": "sha512-avR+36fRxGmZhOMXAFoxHc/wI5OF8fcDJOCnrM2Ss8Cc2F2oAO+ciweenfF6FskpCyyZVrcWe7ZG68BWdkmSNw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@arcgis/toolkit": "~5.0.8",
+        "csstype": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@lit/context": "^1.1.6",
+        "lit": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@lit/context": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esri/calcite-components-react/node_modules/@arcgis/toolkit": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.0.8.tgz",
+      "integrity": "sha512-I8xpz0KBFHOE8qwOi/O0NaRiBQ4NI1It6KlmfH403ZSW3V0wnSVlmlm+FXCrO4UfOICuq9LEUaNK1MlGOnA0Bg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@esri/calcite-components-react/node_modules/@esri/calcite-components": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-5.0.2.tgz",
+      "integrity": "sha512-AE8AQBsdpWWAPJEBc/nabJbdN+H+iuVBJv215mm8xjlyqpHd6BLsD8nG/K8IywDFHeB9TyHLQdYCk/sNiyQo7w==",
+      "license": "SEE LICENSE.md",
+      "dependencies": {
+        "@arcgis/lumina": ">=5.0.0-next.144 <6.0.0",
+        "@arcgis/toolkit": ">=5.0.0-next.144 <6.0.0",
+        "@esri/calcite-ui-icons": "4.4.0",
+        "@floating-ui/dom": "^1.6.12",
+        "@floating-ui/utils": "^0.2.8",
+        "@types/sortablejs": "^1.15.8",
+        "color": "^5.0.3",
+        "composed-offset-position": "^0.0.6",
+        "es-toolkit": "^1.39.8",
+        "focus-trap": "^7.6.5",
+        "interactjs": "^1.10.27",
+        "lit": "^3.3.0",
+        "sortablejs": "^1.15.6",
+        "timezone-groups": "^0.10.4",
+        "type-fest": "^4.30.1"
+      }
+    },
+    "node_modules/@esri/calcite-components-react/node_modules/@esri/calcite-ui-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.4.0.tgz",
+      "integrity": "sha512-PcCGId6vKBysRuuoCIYrVsaC+YVv1lFMqVUQn3Qna0BHOIyf7Mursf3NStELNjYdmL0MRYfmLDEDYQwnAJ/tSA==",
+      "license": "SEE LICENSE.md",
+      "bin": {
+        "spriter": "bin/spriter.js"
+      }
+    },
     "node_modules/@esri/calcite-ui-icons": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.3.0.tgz",
@@ -949,6 +1027,15 @@
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
@@ -1676,14 +1763,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3407,6 +3492,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@arcgis/core": "^4.28.0",
+    "@esri/calcite-components-react": "^5.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { MapViewer } from "./components/Map/MapViewer";
+import type { ValidationResult } from "./types/api";
 
 type UploadResponse = {
   dataset_id: string;
@@ -13,6 +14,9 @@ function App() {
   );
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
@@ -41,6 +45,8 @@ function App() {
 
       const data = (await res.json()) as UploadResponse;
       setCurrentDataset(data);
+      setValidationResult(null);
+      setValidationError(null);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Upload failed";
       setError(msg);
@@ -48,6 +54,32 @@ function App() {
       setIsUploading(false);
       // reset input so same file can be selected again if needed
       event.target.value = "";
+    }
+  }
+
+  async function handleValidate() {
+    if (!currentDataset?.dataset_id) return;
+    setValidationError(null);
+    setValidationResult(null);
+    setIsValidating(true);
+    try {
+      const res = await fetch(`/api/v1/validate/${currentDataset.dataset_id}`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const detail =
+          (typeof data.detail === "string"
+            ? data.detail
+            : data.detail?.detail) ?? res.statusText;
+        throw new Error(detail);
+      }
+      const data = (await res.json()) as ValidationResult;
+      setValidationResult(data);
+    } catch (e) {
+      setValidationError(
+        e instanceof Error ? e.message : "Validation failed"
+      );
+    } finally {
+      setIsValidating(false);
     }
   }
 
@@ -75,6 +107,27 @@ function App() {
             disabled={isUploading}
           />
         </label>
+        <button
+          type="button"
+          onClick={handleValidate}
+          disabled={!currentDataset || isUploading || isValidating}
+          style={{
+            padding: "0.35rem 0.75rem",
+            fontSize: "0.85rem",
+            borderRadius: "4px",
+            border: "1px solid #1976d2",
+            background: !currentDataset || isUploading
+              ? "#e0e0e0"
+              : "#1976d2",
+            color: !currentDataset || isUploading ? "#777" : "#fff",
+            cursor:
+              !currentDataset || isUploading || isValidating
+                ? "not-allowed"
+                : "pointer",
+          }}
+        >
+          {isValidating ? "Validating…" : "Validate geometry"}
+        </button>
         {isUploading && (
           <span style={{ fontSize: "0.85rem", color: "#555" }}>Uploading…</span>
         )}
@@ -88,8 +141,36 @@ function App() {
             {error}
           </span>
         )}
+        {validationError && (
+          <span style={{ fontSize: "0.85rem", color: "#b00020" }}>
+            Validation error: {validationError}
+          </span>
+        )}
       </header>
       <main style={{ flex: 1, minHeight: 0 }}>
+        {validationResult && (
+          <section
+            aria-label="Validation summary"
+            style={{
+              padding: "0.5rem 1rem",
+              borderBottom: "1px solid #eee",
+              background: "#fafafa",
+              fontSize: "0.9rem",
+            }}
+          >
+            {validationResult.issues.length === 0 ? (
+              <span style={{ color: "#2e7d32" }}>
+                No geometry issues found for this dataset.
+              </span>
+            ) : (
+              <span style={{ color: "#b00020" }}>
+                Found {validationResult.issues.length} geometry issue
+                {validationResult.issues.length > 1 ? "s" : ""}. See details in
+                the API response or future UI.
+              </span>
+            )}
+          </section>
+        )}
         <MapViewer
           datasetId={currentDataset?.dataset_id}
           bounds={currentDataset?.bounds ?? null}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,14 @@
+/** API response types (aligned with backend models). */
+
+export type GeometryIssue = {
+  feature_id: unknown;
+  type: string;
+  severity: string;
+  location?: number[] | null;
+  description?: string | null;
+};
+
+export type ValidationResult = {
+  dataset_id: string;
+  issues: GeometryIssue[];
+};


### PR DESCRIPTION
## Summary
Implements **issue #35**: Validation trigger and status display (parent: epic #5 — Simple UI with Calcite).

Adds a "Validate geometry" button to the header that calls the existing `GET /api/v1/validate/{dataset_id}` endpoint and displays the result inline.

## Changes

### Validate button
- **"Validate geometry"** button in the header bar, enabled only when a dataset is loaded.
- Button shows "Validating…" while the request is in flight and is disabled during upload or validation.

### Validation status / progress
- **Loading state:** Button text changes to "Validating…" and is disabled during the API call.
- **Error handling:** If the validation API returns an error, a red inline message shows "Validation error: {message}".

### Validation result display
- **Success (no issues):** Green message — "No geometry issues found for this dataset."
- **Issues found:** Red message — "Found N geometry issue(s)." displayed in a summary section above the map.
- Results are cleared when a new dataset is uploaded.

### Types and dependencies
- Added `frontend/src/types/api.ts` with `GeometryIssue` and `ValidationResult` types (aligned with backend models).
- Installed `@esri/calcite-components-react` dependency (for future Calcite UI work in #37).

## Files changed
- `frontend/src/App.tsx` — Validate button, validation state, result display.
- `frontend/src/types/api.ts` — New file with API response types.
- `frontend/package.json` / `package-lock.json` — Added `@esri/calcite-components-react`.

## How to test
1. `docker compose up --build`
2. Open `http://localhost:3000`
3. Upload a GeoJSON file (e.g. `backend/resources/sample.geojson`)
4. Click **Validate geometry**
5. Confirm the result message appears above the map

Closes #35