### PR TITLE
feat(#37): calcite layout and file upload UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,9 @@
     </script>
     <!-- ArcGIS theme: load as stylesheet (do not import as JS module or browser gets MIME type error) -->
     <link rel="stylesheet" href="https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css" />
+    <!-- Calcite Design System: defines custom elements so React wrappers work -->
+    <script type="module" src="https://js.arcgis.com/calcite-components/5.0"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@5.0.2/dist/calcite/calcite.css" />
   </head>
   <body>
     <div id="root">

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@arcgis/core": "^4.28.7",
+        "@esri/calcite-components": "5.0.2",
         "@esri/calcite-components-react": "^5.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -38,6 +39,87 @@
         "sortablejs": "~1.15.0"
       }
     },
+    "node_modules/@arcgis/core/node_modules/@esri/calcite-components": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.11.0.tgz",
+      "integrity": "sha512-H0ZqX3fEv4i0JCBEZ5SarPpd1KeXvqlEpLTtforfifIYbFAQOshP5fC2tFSL7j5pECyhBuB7rRhBiFeFejpRDw==",
+      "license": "SEE LICENSE.md",
+      "dependencies": {
+        "@floating-ui/dom": "1.5.3",
+        "@stencil/core": "2.22.3",
+        "@types/color": "3.0.5",
+        "color": "4.2.3",
+        "composed-offset-position": "0.0.4",
+        "dayjs": "1.11.10",
+        "focus-trap": "7.5.4",
+        "lodash-es": "4.17.21",
+        "sortablejs": "1.15.0",
+        "timezone-groups": "0.8.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
+      "license": "MIT"
+    },
+    "node_modules/@arcgis/core/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/@arcgis/core/node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/composed-offset-position": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw==",
+      "license": "MIT"
+    },
     "node_modules/@arcgis/core/node_modules/focus-trap": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
@@ -45,6 +127,49 @@
       "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/sortablejs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==",
+      "license": "MIT"
+    },
+    "node_modules/@arcgis/core/node_modules/timezone-groups": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
+      "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA==",
+      "bin": {
+        "timezone-groups": "dist/cli.cjs"
+      }
+    },
+    "node_modules/@arcgis/lumina": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-5.0.10.tgz",
+      "integrity": "sha512-3Bk63oYbTVkNmHXREFFUnedvxPvAEm/aVXE7mXXwJSEqodq0mJhe/EubnZNI2PMSQa1gjEZTzHZjIzJnqyJkJQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@arcgis/toolkit": "~5.0.10",
+        "csstype": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@lit/context": "^1.1.6",
+        "lit": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@lit/context": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@arcgis/toolkit": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.0.10.tgz",
+      "integrity": "sha512-ZEKolhmoAOl5wl4DoMjn57YqPLNu1QM+x1e3Z4KhwegI9B+An2LXQBM+/UwWPKavKthB8ePPAqXnfctREd2OOQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -737,69 +862,6 @@
       "license": "SEE LICENSE IN README.md"
     },
     "node_modules/@esri/calcite-components": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.11.0.tgz",
-      "integrity": "sha512-H0ZqX3fEv4i0JCBEZ5SarPpd1KeXvqlEpLTtforfifIYbFAQOshP5fC2tFSL7j5pECyhBuB7rRhBiFeFejpRDw==",
-      "license": "SEE LICENSE.md",
-      "dependencies": {
-        "@floating-ui/dom": "1.5.3",
-        "@stencil/core": "2.22.3",
-        "@types/color": "3.0.5",
-        "color": "4.2.3",
-        "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.10",
-        "focus-trap": "7.5.4",
-        "lodash-es": "4.17.21",
-        "sortablejs": "1.15.0",
-        "timezone-groups": "0.8.0"
-      }
-    },
-    "node_modules/@esri/calcite-components-react": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-5.0.2.tgz",
-      "integrity": "sha512-UF6HdVQLd6w7ZqW5ma4KcT7iFru5IlWLDqfnsdH+PAwWQiJj0WZo/8i3cVVKGNgDh2cJdpXmbGdFOoGc7Ui7RA==",
-      "license": "SEE LICENSE.md",
-      "dependencies": {
-        "@arcgis/lumina": ">=5.0.0-next.144 <6.0.0",
-        "@esri/calcite-components": "5.0.2",
-        "@lit/react": "^1.0.8",
-        "lit": "^3.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=18.3",
-        "react-dom": ">=18.3"
-      }
-    },
-    "node_modules/@esri/calcite-components-react/node_modules/@arcgis/lumina": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-5.0.8.tgz",
-      "integrity": "sha512-avR+36fRxGmZhOMXAFoxHc/wI5OF8fcDJOCnrM2Ss8Cc2F2oAO+ciweenfF6FskpCyyZVrcWe7ZG68BWdkmSNw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@arcgis/toolkit": "~5.0.8",
-        "csstype": "^3.1.3",
-        "tslib": "^2.8.1"
-      },
-      "peerDependencies": {
-        "@lit/context": "^1.1.6",
-        "lit": "^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@lit/context": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@esri/calcite-components-react/node_modules/@arcgis/toolkit": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.0.8.tgz",
-      "integrity": "sha512-I8xpz0KBFHOE8qwOi/O0NaRiBQ4NI1It6KlmfH403ZSW3V0wnSVlmlm+FXCrO4UfOICuq9LEUaNK1MlGOnA0Bg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@esri/calcite-components-react/node_modules/@esri/calcite-components": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-5.0.2.tgz",
       "integrity": "sha512-AE8AQBsdpWWAPJEBc/nabJbdN+H+iuVBJv215mm8xjlyqpHd6BLsD8nG/K8IywDFHeB9TyHLQdYCk/sNiyQo7w==",
@@ -822,99 +884,29 @@
         "type-fest": "^4.30.1"
       }
     },
-    "node_modules/@esri/calcite-components-react/node_modules/@esri/calcite-ui-icons": {
+    "node_modules/@esri/calcite-components-react": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-5.0.2.tgz",
+      "integrity": "sha512-UF6HdVQLd6w7ZqW5ma4KcT7iFru5IlWLDqfnsdH+PAwWQiJj0WZo/8i3cVVKGNgDh2cJdpXmbGdFOoGc7Ui7RA==",
+      "license": "SEE LICENSE.md",
+      "dependencies": {
+        "@arcgis/lumina": ">=5.0.0-next.144 <6.0.0",
+        "@esri/calcite-components": "5.0.2",
+        "@lit/react": "^1.0.8",
+        "lit": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.3",
+        "react-dom": ">=18.3"
+      }
+    },
+    "node_modules/@esri/calcite-ui-icons": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.4.0.tgz",
       "integrity": "sha512-PcCGId6vKBysRuuoCIYrVsaC+YVv1lFMqVUQn3Qna0BHOIyf7Mursf3NStELNjYdmL0MRYfmLDEDYQwnAJ/tSA==",
       "license": "SEE LICENSE.md",
       "bin": {
         "spriter": "bin/spriter.js"
-      }
-    },
-    "node_modules/@esri/calcite-components/node_modules/@floating-ui/dom": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.4.2",
-        "@floating-ui/utils": "^0.1.3"
-      }
-    },
-    "node_modules/@esri/calcite-components/node_modules/@floating-ui/utils": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
-      "license": "MIT"
-    },
-    "node_modules/@esri/calcite-components/node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/@esri/calcite-components/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@esri/calcite-components/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/@esri/calcite-components/node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/@esri/calcite-components/node_modules/composed-offset-position": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
-      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw==",
-      "license": "MIT"
-    },
-    "node_modules/@esri/calcite-components/node_modules/focus-trap": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-      "license": "MIT",
-      "dependencies": {
-        "tabbable": "^6.2.0"
-      }
-    },
-    "node_modules/@esri/calcite-components/node_modules/sortablejs": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==",
-      "license": "MIT"
-    },
-    "node_modules/@esri/calcite-components/node_modules/timezone-groups": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
-      "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA==",
-      "bin": {
-        "timezone-groups": "dist/cli.cjs"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -1,38 +1,52 @@
 import { Outlet, NavLink } from "react-router-dom";
+import {
+  CalciteShell,
+  CalciteShellPanel,
+  CalciteNavigation,
+  CalciteNavigationLogo,
+} from "@esri/calcite-components-react";
 
 export function AppLayout() {
   return (
-    <div className="app-layout">
+    <CalciteShell>
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>
-      <header className="app-header" role="banner">
-        <h1 className="app-title">GeoSpatial Data Quality Agent</h1>
-        <nav className="app-nav" aria-label="Main navigation">
-          <NavLink
-            to="/upload"
-            className={({ isActive }) => `app-nav-link${isActive ? " app-nav-link--active" : ""}`}
-            end
-          >
-            Upload
-          </NavLink>
-          <NavLink
-            to="/map"
-            className={({ isActive }) => `app-nav-link${isActive ? " app-nav-link--active" : ""}`}
-          >
-            Map
-          </NavLink>
-          <NavLink
-            to="/status"
-            className={({ isActive }) => `app-nav-link${isActive ? " app-nav-link--active" : ""}`}
-          >
-            Status
-          </NavLink>
-        </nav>
-      </header>
-      <main className="app-main" id="main-content" role="main">
+      <div slot="header">
+        <CalciteNavigation label="Main navigation">
+          <CalciteNavigationLogo slot="logo" heading="GeoSpatial Data Quality Agent" />
+          <nav slot="content-start" className="app-nav" aria-label="Main navigation">
+            <NavLink
+              to="/upload"
+              className={({ isActive }) => `app-nav-link${isActive ? " app-nav-link--active" : ""}`}
+              end
+            >
+              Upload
+            </NavLink>
+            <NavLink
+              to="/map"
+              className={({ isActive }) => `app-nav-link${isActive ? " app-nav-link--active" : ""}`}
+            >
+              Map
+            </NavLink>
+            <NavLink
+              to="/status"
+              className={({ isActive }) => `app-nav-link${isActive ? " app-nav-link--active" : ""}`}
+            >
+              Status
+            </NavLink>
+          </nav>
+        </CalciteNavigation>
+      </div>
+      <CalciteShellPanel slot="panel-start" position="start" displayMode="dock">
+        <div className="app-panel-content">
+          <p className="app-panel-title">Dataset</p>
+          <p className="app-panel-hint">Upload a shapefile or GeoJSON on the Upload page.</p>
+        </div>
+      </CalciteShellPanel>
+      <div className="app-main" id="main-content" role="main" style={{ minHeight: "400px" }}>
         <Outlet />
-      </main>
-    </div>
+      </div>
+    </CalciteShell>
   );
 }

--- a/frontend/src/components/Upload/FileUploader.tsx
+++ b/frontend/src/components/Upload/FileUploader.tsx
@@ -1,0 +1,104 @@
+import { useRef, useState, useCallback } from "react";
+import { CalciteButton, CalciteAlert, CalciteIcon } from "@esri/calcite-components-react";
+import { useApp } from "../../context/AppContext";
+
+const ACCEPT = ".shp,.geojson,.json,.zip";
+const ACCEPT_LIST = [".shp", ".geojson", ".json", ".zip"];
+
+function hasAllowedExtension(name: string): boolean {
+  const ext = name.slice(name.lastIndexOf(".")).toLowerCase();
+  return ACCEPT_LIST.includes(ext);
+}
+
+export function FileUploader() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const { isUploading, error, currentDataset, handleUploadFile } = useApp();
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = e.dataTransfer.files?.[0];
+      if (!file) return;
+      if (!hasAllowedExtension(file.name)) {
+        return;
+      }
+      handleUploadFile(file);
+    },
+    [handleUploadFile]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+  }, []);
+
+  const openFileDialog = () => {
+    inputRef.current?.click();
+  };
+
+  return (
+    <div className="file-uploader">
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPT}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleUploadFile(file);
+          e.target.value = "";
+        }}
+        disabled={isUploading}
+        className="visually-hidden"
+        aria-label="Choose a file to upload"
+      />
+      <div
+        className={`file-uploader-dropzone ${isDragOver ? "file-uploader-dropzone--active" : ""}`}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+      >
+        <CalciteIcon icon="upload" scale="l" />
+        <p className="file-uploader-dropzone-text">
+          Drag and drop a file here, or choose a file to upload.
+        </p>
+        <p className="file-uploader-dropzone-hint">Accepted: .shp, .geojson, .json, .zip</p>
+        <CalciteButton
+          kind="brand"
+          onClick={openFileDialog}
+          disabled={isUploading}
+          label="Choose file"
+        >
+          Choose file
+        </CalciteButton>
+      </div>
+      {isUploading && (
+        <p className="status-message status-message--info" role="status">
+          Uploading…
+        </p>
+      )}
+      {currentDataset && (
+        <CalciteAlert kind="success" open label="Upload successful">
+          <div slot="title">Upload successful</div>
+          <div slot="message">
+            Loaded: <strong>{currentDataset.filename}</strong>
+          </div>
+        </CalciteAlert>
+      )}
+      {error && (
+        <CalciteAlert kind="danger" open label="Upload error">
+          <div slot="title">Upload error</div>
+          <div slot="message">{error}</div>
+        </CalciteAlert>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -16,6 +16,8 @@ type AppContextValue = {
   isValidating: boolean;
   validationError: string | null;
   handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+  /** Upload a single file (used by file input and drag-drop). */
+  handleUploadFile: (file: File) => Promise<void>;
   handleValidate: () => Promise<void>;
   clearValidation: () => void;
 };
@@ -30,9 +32,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
-  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (!file) return;
+  async function handleUploadFile(file: File) {
     setError(null);
     setIsUploading(true);
     try {
@@ -53,8 +53,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
       setError(e instanceof Error ? e.message : "Upload failed");
     } finally {
       setIsUploading(false);
-      event.target.value = "";
     }
+  }
+
+  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    await handleUploadFile(file);
+    event.target.value = "";
   }
 
   async function handleValidate() {
@@ -95,6 +101,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         isValidating,
         validationError,
         handleFileChange,
+        handleUploadFile,
         handleValidate,
         clearValidation,
       }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -70,13 +70,18 @@ body {
   outline-offset: var(--focus-ring-offset);
 }
 
-/* Layout */
+/* Layout (Calcite Shell provides main structure; keep utilities for non-shell pages) */
 .app-layout {
   position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
   min-height: 0;
+}
+
+/* Main content area inside Calcite Shell */
+calcite-shell .app-main {
+  padding: 1rem;
 }
 
 .app-header {
@@ -135,10 +140,34 @@ body {
   overflow: auto;
 }
 
+/* Calcite Shell panel content */
+.app-panel-content {
+  padding: 1rem;
+}
+
+.app-panel-title {
+  margin: 0 0 0.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.app-panel-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6a6a6a;
+}
+
 /* Pages */
 .page-section {
   padding: 1rem;
   max-width: 60rem;
+  min-height: 20rem;
+}
+
+.page-section-description {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  color: #404040;
 }
 
 .page-section--map {
@@ -167,6 +196,45 @@ body {
 
 .upload-input {
   font-size: 0.9rem;
+}
+
+/* FileUploader (drag-drop + file input) */
+.file-uploader {
+  margin-top: 0.5rem;
+}
+
+.file-uploader-dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  border: 2px dashed #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.file-uploader-dropzone--active {
+  border-color: #0079c1;
+  background: #e8f4fc;
+}
+
+.file-uploader-dropzone-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #404040;
+}
+
+.file-uploader-dropzone-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6a6a6a;
+}
+
+.file-uploader calcite-alert {
+  margin-top: 1rem;
 }
 
 .status-message {

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,39 +1,15 @@
-import { useApp } from "../context/AppContext";
+import { CalciteBlock } from "@esri/calcite-components-react";
+import { FileUploader } from "../components/Upload/FileUploader";
 
 export function UploadPage() {
-  const { currentDataset, isUploading, error, handleFileChange } = useApp();
-
   return (
     <section className="page-section" aria-labelledby="upload-heading">
-      <h2 id="upload-heading" className="page-heading">
-        Upload dataset
-      </h2>
-      <label className="upload-label">
-        <span className="upload-label-text">Choose a GeoJSON or JSON file</span>
-        <input
-          type="file"
-          accept=".geojson,.json"
-          onChange={handleFileChange}
-          disabled={isUploading}
-          aria-describedby={error ? "upload-error" : currentDataset ? "upload-success" : undefined}
-          className="upload-input"
-        />
-      </label>
-      {isUploading && (
-        <p className="status-message status-message--info" role="status">
-          Uploading…
+      <CalciteBlock heading="Upload dataset" id="upload-heading" expanded collapsible={false}>
+        <p className="page-section-description">
+          Upload a shapefile or GeoJSON to validate and view on the map.
         </p>
-      )}
-      {currentDataset && (
-        <p id="upload-success" className="status-message status-message--success">
-          Loaded: <strong>{currentDataset.filename}</strong>
-        </p>
-      )}
-      {error && (
-        <p id="upload-error" className="status-message status-message--error" role="alert">
-          {error}
-        </p>
-      )}
+        <FileUploader />
+      </CalciteBlock>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Add Calcite Shell + Navigation with a dataset side panel.
- Implement Upload page using Calcite Block and new FileUploader component.
- FileUploader supports drag-and-drop and file input for .shp/.geojson/.json/.zip, calling POST /upload and showing Calcite alerts for success/error.

## Test plan
- Run backend and frontend.
- Navigate to Upload page and verify Calcite layout renders with Dataset panel and Upload block.
- Upload a valid GeoJSON or shapefile (or ZIP) via drag-drop and via Choose file; confirm success alert shows filename and no errors in console.
- Upload an unsupported extension; confirm error alert and no backend crash.
- Navigate to Map and Status routes to ensure layout still works.
