### PR TITLE
feat(#51): trigger validation and store results

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, type ReactNode } from "react";
-import type { ValidationResult } from "../types/api";
+import type { GeometryIssue, ValidationResult } from "../types/api";
 
 export type UploadResponse = {
   dataset_id: string;
@@ -13,6 +13,8 @@ type AppContextValue = {
   isUploading: boolean;
   error: string | null;
   validationResult: ValidationResult | null;
+  /** Stored validation issues (for map/symbolize). Empty when no result or no issues. */
+  validationIssues: GeometryIssue[];
   isValidating: boolean;
   validationError: string | null;
   handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
@@ -98,6 +100,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         isUploading,
         error,
         validationResult,
+        validationIssues: validationResult?.issues ?? [],
         isValidating,
         validationError,
         handleFileChange,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -263,6 +263,14 @@ calcite-shell .app-main {
   margin-top: 1rem;
 }
 
+.upload-validate-block {
+  margin-top: 1rem;
+}
+
+.validation-summary-inline {
+  margin-top: 0.5rem;
+}
+
 .empty-state {
   margin: 0;
   padding: 1rem;

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,7 +1,16 @@
-import { CalciteBlock } from "@esri/calcite-components-react";
+import { CalciteBlock, CalciteButton } from "@esri/calcite-components-react";
 import { FileUploader } from "../components/Upload/FileUploader";
+import { useApp } from "../context/AppContext";
 
 export function UploadPage() {
+  const {
+    currentDataset,
+    validationResult,
+    isValidating,
+    validationError,
+    handleValidate,
+  } = useApp();
+
   return (
     <section className="page-section" aria-labelledby="upload-heading">
       <CalciteBlock heading="Upload dataset" id="upload-heading" expanded collapsible={false}>
@@ -10,6 +19,39 @@ export function UploadPage() {
         </p>
         <FileUploader />
       </CalciteBlock>
+      {currentDataset && (
+        <CalciteBlock
+          heading="Run validation"
+          className="upload-validate-block"
+          expanded
+          collapsible={false}
+        >
+          <p className="page-section-description">
+            Run geometry validation on the current dataset. Results are stored for the map.
+          </p>
+          <CalciteButton
+            kind="brand"
+            onClick={handleValidate}
+            disabled={isValidating}
+            loading={isValidating}
+            label={isValidating ? "Validating…" : "Validate geometry"}
+          >
+            {isValidating ? "Validating…" : "Validate geometry"}
+          </CalciteButton>
+          {validationError && (
+            <p className="status-message status-message--error" role="alert">
+              {validationError}
+            </p>
+          )}
+          {validationResult && (
+            <p className="status-message validation-summary-inline" role="status">
+              {validationResult.issues.length === 0
+                ? "No geometry issues found."
+                : `Found ${validationResult.issues.length} issue${validationResult.issues.length !== 1 ? "s" : ""}.`}
+            </p>
+          )}
+        </CalciteBlock>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Implements **issue #51** ([#47] Trigger validation and get results): ensure validation can be run for the current dataset from the UI and that results (list of `GeometryIssue`) are stored for downstream use (e.g. map in #52).

## Changes
- **AppContext:** Expose `validationIssues` (derived from `validationResult?.issues`) so the map and other consumers can use the stored list of issues (`feature_id`, `type`, `severity`, `location`, `description`).
- **Upload page:** When a dataset is loaded, show a **Run validation** block with a **Validate geometry** button that calls `GET /api/v1/validate/{dataset_id}` and displays loading, error, and result summary (issue count).
- **Styles:** Spacing for the validation block and inline summary on Upload.

Validation can now be triggered from both **Upload** and **Status**; the API response is stored in context and available as `validationResult` and `validationIssues`.

## Test
- Upload a GeoJSON/shapefile, click **Validate geometry** on Upload page → loading then success/error and issue count.
- Same flow from Status page; result is shared across pages.

Closes #51