### PR TITLE
feat(#52): pass validation issues into map

### DIFF
--- a/frontend/src/components/Map/MapViewer.tsx
+++ b/frontend/src/components/Map/MapViewer.tsx
@@ -6,6 +6,7 @@ import GeoJSONLayer from "@arcgis/core/layers/GeoJSONLayer.js";
 import Extent from "@arcgis/core/geometry/Extent.js";
 import Zoom from "@arcgis/core/widgets/Zoom.js";
 
+import type { GeometryIssue } from "../../types/api";
 import { defaultCenter, defaultZoom } from "../../services/mapService";
 
 /* ArcGIS theme loaded via <link> in index.html to avoid loading CSS as module (MIME type error) */
@@ -22,9 +23,11 @@ export type MapViewerProps = {
   bounds?: number[] | null;
   /** Optional title for the dataset layer (e.g. filename) for the layer list. */
   layerTitle?: string;
+  /** Validation issues for the current dataset (for highlight/symbolize in #53). */
+  validationIssues?: GeometryIssue[];
 };
 
-export function MapViewer({ datasetId, bounds, layerTitle }: MapViewerProps) {
+export function MapViewer({ datasetId, bounds, layerTitle, validationIssues }: MapViewerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
   const viewRef = useRef<MapView | null>(null);

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -2,7 +2,7 @@ import { MapViewer } from "../components/Map/MapViewer";
 import { useApp } from "../context/AppContext";
 
 export function MapPage() {
-  const { currentDataset } = useApp();
+  const { currentDataset, validationIssues } = useApp();
 
   return (
     <section className="page-section page-section--map" aria-labelledby="map-heading">
@@ -18,6 +18,7 @@ export function MapPage() {
           datasetId={currentDataset.dataset_id}
           bounds={currentDataset.bounds ?? null}
           layerTitle={currentDataset.filename}
+          validationIssues={validationIssues}
         />
       )}
     </section>


### PR DESCRIPTION
## Summary
Implements **issue #52** ([#47] Pass validation issues into the map): pass validation issues from app state into `MapViewer` so the map can consume them (e.g. for highlight/symbolize in #53).

## Changes
- **MapViewer:** Add optional prop `validationIssues?: GeometryIssue[]`; import `GeometryIssue` from API types. Prop is ready for use in #53.
- **MapPage:** Read `validationIssues` from `useApp()` and pass it to `MapViewer` as `validationIssues={validationIssues}`.

Validation issues (from #51) are now available inside the map component. No visual change yet; that is #53.

## Test
- Upload a dataset, run validation (Upload or Status), open Map tab — map still loads; `MapViewer` receives `validationIssues` from context.

Closes #52