### PR TITLE
feat: validate button on Map page and popups for issue markers

### DIFF
--- a/frontend/src/components/Map/MapViewer.tsx
+++ b/frontend/src/components/Map/MapViewer.tsx
@@ -24,6 +24,12 @@ const DATASET_LAYER_ID = "dataset-layer";
 const ISSUES_LAYER_ID = "validation-issues-layer";
 const WKID_WGS84 = 4326;
 
+function escapeHtml(s: string): string {
+  const el = document.createElement("div");
+  el.textContent = s;
+  return el.innerHTML;
+}
+
 export type MapViewerProps = {
   datasetId?: string;
   bounds?: number[] | null;
@@ -60,6 +66,34 @@ export function MapViewer({ datasetId, bounds, layerTitle, validationIssues }: M
 
     const zoom = new Zoom({ view, layout: "vertical" });
     view.ui.add(zoom, "top-right");
+
+    view.on("click", async (event) => {
+      const hit = await view.hitTest(event);
+      const issuesLayer = issuesLayerRef.current;
+      if (!issuesLayer) return;
+      let graphic: __esri.Graphic | null = null;
+      for (const r of hit.results) {
+        const g = (r as { graphic?: __esri.Graphic }).graphic;
+        if (g && g.layer === issuesLayer) {
+          graphic = g;
+          break;
+        }
+      }
+      if (!graphic?.attributes) return;
+      const { type, severity, description } = graphic.attributes as {
+        type?: string;
+        severity?: string;
+        description?: string;
+      };
+      const safeType = escapeHtml(String(type ?? ""));
+      const safeSeverity = escapeHtml(String(severity ?? ""));
+      const safeDesc = escapeHtml(String(description ?? ""));
+      view.popup.open({
+        location: graphic.geometry as __esri.Point,
+        title: "Validation issue",
+        content: `<p><strong>Type:</strong> ${safeType}</p><p><strong>Severity:</strong> ${safeSeverity}</p><p><strong>Description:</strong> ${safeDesc || "—"}</p>`,
+      });
+    });
 
     return () => {
       if (viewRef.current) {

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,8 +1,16 @@
+import { CalciteBlock, CalciteButton } from "@esri/calcite-components-react";
 import { MapViewer } from "../components/Map/MapViewer";
 import { useApp } from "../context/AppContext";
 
 export function MapPage() {
-  const { currentDataset, validationIssues } = useApp();
+  const {
+    currentDataset,
+    validationIssues,
+    validationResult,
+    isValidating,
+    validationError,
+    handleValidate,
+  } = useApp();
 
   return (
     <section className="page-section page-section--map" aria-labelledby="map-heading">
@@ -14,12 +22,45 @@ export function MapPage() {
           Upload a dataset on the <strong>Upload</strong> tab to view it on the map.
         </p>
       ) : (
-        <MapViewer
-          datasetId={currentDataset.dataset_id}
-          bounds={currentDataset.bounds ?? null}
-          layerTitle={currentDataset.filename}
-          validationIssues={validationIssues}
-        />
+        <>
+          <CalciteBlock
+            heading="Validate dataset"
+            className="map-validate-block"
+            expanded={false}
+            collapsible
+          >
+            <p className="page-section-description">
+              Run geometry validation and see issues on the map. Click a red marker to see details.
+            </p>
+            <CalciteButton
+              kind="brand"
+              onClick={handleValidate}
+              disabled={isValidating}
+              loading={isValidating}
+              label={isValidating ? "Validating…" : "Validate dataset"}
+            >
+              {isValidating ? "Validating…" : "Validate dataset"}
+            </CalciteButton>
+            {validationError && (
+              <p className="status-message status-message--error" role="alert">
+                {validationError}
+              </p>
+            )}
+            {validationResult && (
+              <p className="status-message validation-summary-inline" role="status">
+                {validationResult.issues.length === 0
+                  ? "No geometry issues found."
+                  : `Found ${validationResult.issues.length} issue${validationResult.issues.length !== 1 ? "s" : ""}. Click markers on the map for details.`}
+              </p>
+            )}
+          </CalciteBlock>
+          <MapViewer
+            datasetId={currentDataset.dataset_id}
+            bounds={currentDataset.bounds ?? null}
+            layerTitle={currentDataset.filename}
+            validationIssues={validationIssues}
+          />
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
Adds optional UX for running validation from the Map view and viewing issue details.

## Changes
- **Validate button on Map page**: Collapsible "Validate dataset" block with a button that triggers the validation API and updates the map with issue markers. Shows loading state, errors, and result summary (e.g. "Found N issues. Click markers on the map for details.").
- **Issue popups**: Clicking a red validation-issue marker on the map opens a popup with **Type**, **Severity**, and **Description** (content is HTML-escaped for safety).

Closes #54