### PR TITLE
feat(agents): add ValidationState and use in orchestrator

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,1 +1,4 @@
-# Agents: geometry_agent, etc.
+# Agents: geometry_agent, state, orchestrator.
+from agents.state import ValidationState, empty_state
+
+__all__ = ["ValidationState", "empty_state"]

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1,0 +1,9 @@
+"""
+LangGraph orchestration for the validation pipeline.
+
+Coordinates geometry, attribute, and topology agents with shared ValidationState.
+Full graph construction (nodes + edges + conditional routing) is in issue #61.
+"""
+from agents.state import ValidationState, empty_state
+
+__all__ = ["ValidationState", "empty_state"]

--- a/backend/agents/state.py
+++ b/backend/agents/state.py
@@ -1,0 +1,44 @@
+"""
+Shared state schema for the LangGraph validation pipeline.
+
+Used by the orchestrator and all validation agents (geometry, attribute, topology)
+so they read and update a single state object.
+"""
+from typing import Any, List, Optional, TypedDict
+
+from api.models import GeometryIssue
+
+
+class ValidationState(TypedDict, total=False):
+    """
+    State passed through the validation workflow.
+
+    All keys are optional (total=False) so graph nodes can return partial updates.
+    Aligns with API models: issues use GeometryIssue; dataset_id matches ValidationResult.
+    """
+
+    dataset_id: str
+    """Dataset identifier (from upload). Matches ValidationResult.dataset_id."""
+
+    dataset_path: Optional[str]
+    """Path to the vector file on disk, for agents that need to load the dataset."""
+
+    issues: List[GeometryIssue]
+    """All validation issues found (geometry, attribute, topology)."""
+
+    corrections: List[dict]
+    """Suggested or applied corrections. Structure TBD by recommendation agent."""
+
+    user_approvals: List[bool]
+    """User decisions per correction (e.g. approve/reject)."""
+
+
+def empty_state(dataset_id: str, dataset_path: Optional[str] = None) -> dict[str, Any]:
+    """Return an initial ValidationState for a new run."""
+    return {
+        "dataset_id": dataset_id,
+        "dataset_path": dataset_path,
+        "issues": [],
+        "corrections": [],
+        "user_approvals": [],
+    }


### PR DESCRIPTION
## Summary
Defines the shared state schema for the LangGraph validation pipeline and wires it into the orchestrator (issue #60).

## Changes
- **`backend/agents/state.py`** (new):
  - `ValidationState` TypedDict with `dataset_id`, `dataset_path`, `issues` (List[GeometryIssue]), `corrections`, `user_approvals`; `total=False` for partial updates.
  - `empty_state(dataset_id, dataset_path=None)` helper for initial state.
  - Aligns with existing API models (`GeometryIssue`, `ValidationResult`).
- **`backend/agents/orchestrator.py`** (new): Imports and re-exports `ValidationState` and `empty_state`; placeholder for full graph (issue #61).
- **`backend/agents/__init__.py`**: Re-exports `ValidationState` and `empty_state`.

## Verification
- Lint clean; backend tests pass; imports verified.

Closes #60