### PR TITLE
feat(agents): build StateGraph with nodes and edges

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,4 +1,5 @@
-# Agents: geometry_agent, state, orchestrator.
+# Agents: geometry_agent, state, orchestrator, attribute_agent, topology_agent, recommendation_agent.
 from agents.state import ValidationState, empty_state
+from agents.orchestrator import validation_graph
 
-__all__ = ["ValidationState", "empty_state"]
+__all__ = ["ValidationState", "empty_state", "validation_graph"]

--- a/backend/agents/attribute_agent.py
+++ b/backend/agents/attribute_agent.py
@@ -1,0 +1,11 @@
+"""Attribute validation agent: consistency, outliers, missing values (LLM-assisted). Stub for #61."""
+from agents.state import ValidationState
+
+
+def run(state: ValidationState) -> dict:
+    """
+    Run attribute validation on the dataset in state.
+    Returns partial state update (e.g. {"issues": [...]}).
+    Stub: no-op until attribute validation is implemented.
+    """
+    return {}

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -2,8 +2,60 @@
 LangGraph orchestration for the validation pipeline.
 
 Coordinates geometry, attribute, and topology agents with shared ValidationState.
-Full graph construction (nodes + edges + conditional routing) is in issue #61.
+StateGraph with nodes and edges (issue #61); conditional routing in #62.
 """
-from agents.state import ValidationState, empty_state
+from typing import Any
 
-__all__ = ["ValidationState", "empty_state"]
+from api.models import GeometryIssue
+from langgraph.graph import StateGraph
+
+from agents.attribute_agent import run as attribute_validation
+from agents.geometry_agent import validate as run_geometry_validation
+from agents.recommendation_agent import run as generate_recommendations
+from agents.state import ValidationState, empty_state
+from agents.topology_agent import run as topology_validation
+
+
+def _dict_to_geometry_issue(d: dict) -> GeometryIssue:
+    """Convert geometry agent output dict to GeometryIssue model."""
+    return GeometryIssue(
+        feature_id=d.get("feature_id"),
+        type=d.get("type", ""),
+        severity=d.get("severity", ""),
+        location=d.get("location"),
+        description=d.get("description"),
+    )
+
+
+def _geometry_validation_node(state: ValidationState) -> dict[str, Any]:
+    """Node: run geometry validation and append issues to state."""
+    path = state.get("dataset_path")
+    existing = list(state.get("issues") or [])
+    if not path:
+        return {"issues": existing}
+    raw = run_geometry_validation(path)
+    new_issues = [_dict_to_geometry_issue(d) for d in raw]
+    return {"issues": existing + new_issues}
+
+
+def _build_graph() -> Any:
+    """Build and compile the validation StateGraph."""
+    workflow_builder = StateGraph(ValidationState)
+
+    workflow_builder.add_node("geometry_validation", _geometry_validation_node)
+    workflow_builder.add_node("attribute_validation", attribute_validation)
+    workflow_builder.add_node("topology_validation", topology_validation)
+    workflow_builder.add_node("generate_recommendations", generate_recommendations)
+
+    workflow_builder.set_entry_point("geometry_validation")
+    workflow_builder.add_edge("geometry_validation", "attribute_validation")
+    workflow_builder.add_edge("attribute_validation", "topology_validation")
+    workflow_builder.add_edge("topology_validation", "generate_recommendations")
+
+    return workflow_builder.compile()
+
+
+# Compiled graph for API use (issue #63)
+validation_graph = _build_graph()
+
+__all__ = ["ValidationState", "empty_state", "validation_graph"]

--- a/backend/agents/recommendation_agent.py
+++ b/backend/agents/recommendation_agent.py
@@ -1,0 +1,11 @@
+"""Recommendation agent: generate correction suggestions from issues. Stub for #61."""
+from agents.state import ValidationState
+
+
+def run(state: ValidationState) -> dict:
+    """
+    Generate correction recommendations from current issues.
+    Returns partial state update (e.g. {"corrections": [...]}).
+    Stub: returns empty corrections until recommendation logic is implemented.
+    """
+    return {"corrections": []}

--- a/backend/agents/topology_agent.py
+++ b/backend/agents/topology_agent.py
@@ -1,0 +1,11 @@
+"""Topology validation agent: gaps, overlaps, connectivity. Stub for #61."""
+from agents.state import ValidationState
+
+
+def run(state: ValidationState) -> dict:
+    """
+    Run topology validation on the dataset in state.
+    Returns partial state update (e.g. {"issues": [...]}).
+    Stub: no-op until topology validation is implemented.
+    """
+    return {}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]>=0.24.0
 python-multipart>=0.0.6
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
+langgraph>=0.2.0
 geopandas>=0.14.0
 pytest>=7.0.0
 pytest-asyncio>=0.21.0


### PR DESCRIPTION
## Summary

This PR implements **issue #61**: build the LangGraph `StateGraph` for the validation pipeline, add the four agent nodes (geometry, attribute, topology, generate_recommendations), set the entry point and linear edges, and compile the graph. The compiled graph is ready to be invoked from the API (issue #63).

---

## Background

- **Parent epic:** #6 (LangGraph workflow implementation).
- **Depends on:** #60 (ValidationState and state schema), which is already merged.
- The README describes a validation pipeline: geometry → attribute → topology → generate_recommendations. This PR implements that structure with a real geometry node and stubs for the others.

---

## Changes

### Dependency
- **`backend/requirements.txt`**  
  - Added `langgraph>=0.2.0` for `StateGraph` and compiled graph execution.

### Orchestrator (`backend/agents/orchestrator.py`)
- **StateGraph(ValidationState)**  
  - Graph state is the shared `ValidationState` (dataset_id, dataset_path, issues, corrections, user_approvals).
- **Nodes**
  1. **`geometry_validation`** — Reads `dataset_path` from state, calls `geometry_agent.validate(path)`, converts each returned dict to `GeometryIssue`, and returns `{"issues": existing_issues + new_issues}`.
  2. **`attribute_validation`** — Wired to `attribute_agent.run`; stub returns `{}` until attribute validation is implemented.
  3. **`topology_validation`** — Wired to `topology_agent.run`; stub returns `{}` until topology validation is implemented.
  4. **`generate_recommendations`** — Wired to `recommendation_agent.run`; stub returns `{"corrections": []}` until recommendation logic is implemented.
- **Entry point:** `set_entry_point("geometry_validation")`.
- **Edges:** Linear flow: `geometry_validation` → `attribute_validation` → `topology_validation` → `generate_recommendations`.
- **Compile:** `validation_graph = workflow_builder.compile()` and exported for use by the validate API.
- **Helper:** `_dict_to_geometry_issue(d)` to map geometry-agent output dicts to `GeometryIssue` (aligned with `api.models`).

### New stub agents
- **`backend/agents/attribute_agent.py`** — `run(state: ValidationState) -> dict`; no-op stub.
- **`backend/agents/topology_agent.py`** — `run(state: ValidationState) -> dict`; no-op stub.
- **`backend/agents/recommendation_agent.py`** — `run(state: ValidationState) -> dict`; returns `{"corrections": []}`.

### Package exports
- **`backend/agents/__init__.py`** — Exports `validation_graph` in addition to `ValidationState` and `empty_state`.

---

## Verification

- **Lint:** No new linter issues in modified/new files.
- **Import and invoke:** `validation_graph.invoke(empty_state("ds1", None))` runs and returns state including `issues`.
- **Tests:** All 18 backend tests pass (`pytest tests/`).

---

## Follow-up

- **#62** — Add conditional routing (e.g. by severity) to the graph.
- **#63** — Expose the compiled workflow via API (e.g. POST/GET validate using `validation_graph.invoke()`).

Closes #61