### PR TITLE
feat(agents): add conditional routing by severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,8 @@ workflow.add_edge("geometry_validation", "attribute_validation")
 workflow.add_edge("attribute_validation", "topology_validation")
 workflow.add_edge("topology_validation", "generate_recommendations")
 
-# Conditional routing based on severity
+# Conditional routing based on severity (see agents/orchestrator.py)
+# route_by_severity: if any issue has severity "critical" -> apply_corrections; else -> END (review).
 workflow.add_conditional_edges(
     "generate_recommendations",
     route_by_severity,

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -2,12 +2,16 @@
 LangGraph orchestration for the validation pipeline.
 
 Coordinates geometry, attribute, and topology agents with shared ValidationState.
-StateGraph with nodes and edges (issue #61); conditional routing in #62.
+StateGraph with nodes and edges (issue #61); conditional routing by severity (issue #62).
+
+Routing logic (after generate_recommendations):
+- If any issue has severity "critical" -> apply_corrections node (stub; apply fixes when implemented).
+- Otherwise -> END (review path; no automatic corrections).
 """
-from typing import Any
+from typing import Any, Literal
 
 from api.models import GeometryIssue
-from langgraph.graph import StateGraph
+from langgraph.graph import END, StateGraph
 
 from agents.attribute_agent import run as attribute_validation
 from agents.geometry_agent import validate as run_geometry_validation
@@ -38,19 +42,50 @@ def _geometry_validation_node(state: ValidationState) -> dict[str, Any]:
     return {"issues": existing + new_issues}
 
 
+def _apply_corrections_node(state: ValidationState) -> dict[str, Any]:
+    """
+    Node: apply user-approved corrections to the dataset.
+    Stub: no-op until correction application is implemented (Phase 2/3).
+    """
+    return {}
+
+
+def _route_by_severity(state: ValidationState) -> Literal["critical", "review"]:
+    """
+    Conditional routing after generate_recommendations.
+
+    - critical: at least one issue has severity "critical" -> run apply_corrections.
+    - review: otherwise -> END (workflow finishes; user can review issues without auto-apply).
+    """
+    issues = state.get("issues") or []
+    for issue in issues:
+        if getattr(issue, "severity", "").lower() == "critical":
+            return "critical"
+    return "review"
+
+
 def _build_graph() -> Any:
-    """Build and compile the validation StateGraph."""
+    """Build and compile the validation StateGraph with conditional routing by severity."""
     workflow_builder = StateGraph(ValidationState)
 
     workflow_builder.add_node("geometry_validation", _geometry_validation_node)
     workflow_builder.add_node("attribute_validation", attribute_validation)
     workflow_builder.add_node("topology_validation", topology_validation)
     workflow_builder.add_node("generate_recommendations", generate_recommendations)
+    workflow_builder.add_node("apply_corrections", _apply_corrections_node)
 
     workflow_builder.set_entry_point("geometry_validation")
     workflow_builder.add_edge("geometry_validation", "attribute_validation")
     workflow_builder.add_edge("attribute_validation", "topology_validation")
     workflow_builder.add_edge("topology_validation", "generate_recommendations")
+
+    # Conditional routing: critical issues -> apply_corrections; else -> END (review)
+    workflow_builder.add_conditional_edges(
+        "generate_recommendations",
+        _route_by_severity,
+        path_map={"critical": "apply_corrections", "review": END},
+    )
+    workflow_builder.add_edge("apply_corrections", END)
 
     return workflow_builder.compile()
 


### PR DESCRIPTION
## Summary

This PR implements **issue #62** of epic **issue #6**: add conditional routing to the LangGraph validation workflow so the graph branches after `generate_recommendations` based on issue severity (critical → apply_corrections, otherwise → END for review). Routing logic is documented in code and in the README.

---

## Background

- **Parent epic:** #6 (LangGraph workflow implementation).
- **Builds on:** #61 (StateGraph with nodes and edges). The graph currently has a linear flow; this PR adds the first conditional branch.
- The README describes conditional routing: after recommendations, route by severity to either `apply_corrections` or end (review).

---

## Changes

### Orchestrator (`backend/agents/orchestrator.py`)

- **Module docstring** — Documents routing behaviour: after `generate_recommendations`, critical issues → `apply_corrections`, else → END (review).
- **`_apply_corrections_node(state)`** — New stub node that returns `{}`. Placeholder until correction application is implemented (Phase 2/3).
- **`_route_by_severity(state)`** — New router used by conditional edges:
  - Reads `state["issues"]` and checks each issue's `severity` (case-insensitive).
  - Returns `"critical"` if any issue has severity `"critical"`.
  - Otherwise returns `"review"`.
  - Docstring explains both outcomes.
- **Graph wiring:**
  - Add node `apply_corrections` → `_apply_corrections_node`.
  - Replace the single edge out of `generate_recommendations` with **conditional edges**: `add_conditional_edges("generate_recommendations", _route_by_severity, path_map={"critical": "apply_corrections", "review": END})`.
  - Add edge `apply_corrections` → `END` so the graph terminates after the apply step.
- **Imports:** `END` from `langgraph.graph`, `Literal` for router return type.

### README (`README.md`)

- In the **Agent Workflow** code example (conditional routing section), added a short comment that:
  - Points to `agents/orchestrator.py` for the implementation.
  - States the rule: if any issue has severity `"critical"` → `apply_corrections`; else → END (review).

---

## Verification

- **Lint:** No new issues in modified files.
- **Invoke:**
  - State with no critical issues → graph goes to END (review path).
  - State with at least one `severity="critical"` issue → graph runs `apply_corrections` then END.
- **Tests:** All 18 backend tests pass.

---

## Follow-up

- **#63** — Expose the compiled workflow via API (e.g. validate endpoint using `validation_graph.invoke()`).
- Future: Implement real logic in `_apply_corrections_node` when correction application is in scope.

Closes #62