### PR TITLE
feat(api): expose LangGraph workflow via validate endpoints

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
-from api.models import ErrorCode, ErrorResponse, GeometryIssue, UploadResponse, ValidateRequest, ValidationResult
+from api.models import ErrorCode, ErrorResponse, UploadResponse, ValidateRequest, ValidationResult
 from core.config import settings
 from services.file_handler import (
     extract_zip_in_upload_dir,
@@ -15,7 +15,7 @@ from services.file_handler import (
 )
 from services.geojson_parser import parse_geojson_metadata
 from services.shapefile_parser import parse_shapefile_metadata
-from agents.geometry_agent import validate as run_geometry_validation
+from agents.orchestrator import empty_state, validation_graph
 
 router = APIRouter()
 
@@ -120,9 +120,9 @@ async def upload_dataset(file: UploadFile = File(..., description="Shapefile, Ge
 )
 async def validate_dataset(body: ValidateRequest):
     """
-    Run geometry validation on an uploaded dataset (by dataset_id).
-    Checks: null/empty geometry, invalid geometry, self-intersection.
-    Returns list of issues with feature_id, type, severity, location, description.
+    Run the LangGraph validation workflow on an uploaded dataset (by dataset_id).
+    Runs geometry, attribute, topology agents and generate_recommendations;
+    routes by severity (critical -> apply_corrections). Returns issues for frontend.
     """
     path = get_primary_vector_path(body.dataset_id)
     if path is None or not path.exists():
@@ -133,8 +133,10 @@ async def validate_dataset(body: ValidateRequest):
                 "code": ErrorCode.DATASET_NOT_FOUND,
             },
         )
-    issues = run_geometry_validation(path)
-    return ValidationResult(dataset_id=body.dataset_id, issues=[_issue_to_model(i) for i in issues])
+    initial_state = empty_state(body.dataset_id, str(path))
+    final_state = validation_graph.invoke(initial_state)
+    issues = final_state.get("issues") or []
+    return ValidationResult(dataset_id=body.dataset_id, issues=issues)
 
 
 @router.get(
@@ -147,8 +149,8 @@ async def validate_dataset(body: ValidateRequest):
 )
 async def get_validation_results(dataset_id: str):
     """
-    Run geometry validation for a dataset and return results (same as POST /validate).
-    Checks: null/empty geometry, invalid geometry, self-intersection.
+    Run the LangGraph validation workflow for a dataset and return results (same as POST /validate).
+    Runs geometry, attribute, topology agents; returns issues for frontend.
     """
     path = get_primary_vector_path(dataset_id)
     if path is None or not path.exists():
@@ -159,8 +161,10 @@ async def get_validation_results(dataset_id: str):
                 "code": ErrorCode.DATASET_NOT_FOUND,
             },
         )
-    issues = run_geometry_validation(path)
-    return ValidationResult(dataset_id=dataset_id, issues=[_issue_to_model(i) for i in issues])
+    initial_state = empty_state(dataset_id, str(path))
+    final_state = validation_graph.invoke(initial_state)
+    issues = final_state.get("issues") or []
+    return ValidationResult(dataset_id=dataset_id, issues=issues)
 
 
 @router.get(
@@ -194,14 +198,3 @@ async def get_dataset_geojson(dataset_id: str):
             },
         )
     return FileResponse(path, media_type="application/geo+json")
-
-
-def _issue_to_model(d: dict) -> GeometryIssue:
-    """Convert validation issue dict to GeometryIssue model."""
-    return GeometryIssue(
-        feature_id=d.get("feature_id"),
-        type=d.get("type", ""),
-        severity=d.get("severity", ""),
-        location=d.get("location"),
-        description=d.get("description"),
-    )


### PR DESCRIPTION
## Summary

This PR implements **issue #63**: expose the compiled LangGraph validation workflow via the API. The validate endpoints (`POST /validate` and `GET /validate/{dataset_id}`) now invoke the full workflow (geometry → attribute → topology → generate_recommendations → conditional routing by severity) instead of calling the geometry agent directly. Results are returned as `ValidationResult` for frontend consumption.

---

## Related Issues

- **Closes #63** — Compile workflow and expose via API
- **Parent epic:** #6 (LangGraph workflow implementation)
- **Builds on:** #60 (ValidationState), #61 (StateGraph with nodes/edges), #62 (conditional routing by severity)

---

## Background

- The LangGraph workflow (`validation_graph`) is already compiled in `agents/orchestrator.py` and runs: geometry_validation → attribute_validation → topology_validation → generate_recommendations → (conditional) apply_corrections or END.
- Previously, the validate endpoints called `geometry_agent.validate(path)` directly, bypassing the graph.
- This PR wires the API to the graph so the full pipeline runs and the frontend receives the same `ValidationResult` shape.

---

## Changes

### `backend/api/routes.py`

- **Imports:** Replaced `agents.geometry_agent.validate` with `agents.orchestrator.empty_state` and `validation_graph`. Removed unused `GeometryIssue` import.
- **`POST /validate`:**
  - Builds initial state with `empty_state(body.dataset_id, str(path))`.
  - Calls `validation_graph.invoke(initial_state)`.
  - Returns `ValidationResult(dataset_id=..., issues=final_state.get("issues") or [])`.
  - Updated docstring to describe the LangGraph workflow.
- **`GET /validate/{dataset_id}`:** Same flow as POST.
- **Removed:** `_issue_to_model` helper (no longer needed; graph returns `GeometryIssue` instances directly).

---

## Verification

- **Response format:** Unchanged — `ValidationResult` with `dataset_id` and `issues: List[GeometryIssue]`.
- **Frontend compatibility:** No frontend changes required; existing `GET /api/v1/validate/{dataset_id}` usage continues to work.
- **Tests:** All 18 backend tests pass.

---

## Follow-up

- **#64** — Async/task-based execution with status polling (optional; current sync invoke is sufficient for Phase 2).

Closes #63