### PR TITLE
feat(api): async validation jobs and status polling

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -43,6 +43,18 @@ class ValidationResult(BaseModel):
     issues: List[GeometryIssue] = Field(default_factory=list, description="List of geometry issues found")
 
 
+class ValidationJobStatus(BaseModel):
+    """Status of an asynchronous validation job."""
+
+    job_id: str = Field(..., description="Unique identifier for the validation job")
+    dataset_id: str = Field(..., description="Dataset identifier that is being validated")
+    status: str = Field(..., description="Job status: pending, running, completed, or failed")
+    error: Optional[str] = Field(None, description="Error message when status is failed")
+    result: Optional[ValidationResult] = Field(
+        None, description="ValidationResult when status is completed (may be omitted for large payloads)"
+    )
+
+
 class ValidateRequest(BaseModel):
     """Request body for POST /validate."""
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,10 +1,11 @@
 """API route handlers."""
 from io import BytesIO
 from pathlib import Path
+import uuid
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, BackgroundTasks, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
-from api.models import ErrorCode, ErrorResponse, UploadResponse, ValidateRequest, ValidationResult
+from api.models import ErrorCode, ErrorResponse, UploadResponse, ValidationJobStatus, ValidateRequest, ValidationResult
 from core.config import settings
 from services.file_handler import (
     extract_zip_in_upload_dir,
@@ -18,6 +19,9 @@ from services.shapefile_parser import parse_shapefile_metadata
 from agents.orchestrator import empty_state, validation_graph
 
 router = APIRouter()
+
+# In-memory store for async validation jobs (issue #64).
+_validation_jobs: dict[str, dict] = {}
 
 
 def _allowed_file(filename: str) -> bool:
@@ -165,6 +169,93 @@ async def get_validation_results(dataset_id: str):
     final_state = validation_graph.invoke(initial_state)
     issues = final_state.get("issues") or []
     return ValidationResult(dataset_id=dataset_id, issues=issues)
+
+
+@router.post(
+    "/validate/async",
+    response_model=ValidationJobStatus,
+    responses={
+        200: {"description": "Enqueue async validation job"},
+        404: {"description": "Dataset not found", "model": ErrorResponse},
+    },
+)
+async def validate_dataset_async(body: ValidateRequest, background_tasks: BackgroundTasks):
+    """
+    Run validation asynchronously using the LangGraph workflow.
+
+    Returns immediately with a job_id; the job can be polled via GET /validate/jobs/{job_id}.
+    """
+    path = get_primary_vector_path(body.dataset_id)
+    if path is None or not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "detail": f"Dataset not found or no vector file: {body.dataset_id}",
+                "code": ErrorCode.DATASET_NOT_FOUND,
+            },
+        )
+
+    job_id = str(uuid.uuid4())
+    _validation_jobs[job_id] = {
+        "job_id": job_id,
+        "dataset_id": body.dataset_id,
+        "status": "pending",
+        "error": None,
+        "result": None,
+    }
+
+    def _run_job(jid: str, dataset_id: str, dataset_path: str) -> None:
+        # Mark as running
+        job = _validation_jobs.get(jid)
+        if not job:
+            return
+        job["status"] = "running"
+        try:
+            state = empty_state(dataset_id, dataset_path)
+            final_state = validation_graph.invoke(state)
+            issues = final_state.get("issues") or []
+            result = ValidationResult(dataset_id=dataset_id, issues=issues)
+            job["result"] = result
+            job["status"] = "completed"
+        except Exception as exc:  # noqa: BLE001
+            job["status"] = "failed"
+            job["error"] = str(exc)
+
+    background_tasks.add_task(_run_job, job_id, body.dataset_id, str(path))
+
+    return ValidationJobStatus(
+        job_id=job_id,
+        dataset_id=body.dataset_id,
+        status="pending",
+        error=None,
+        result=None,
+    )
+
+
+@router.get(
+    "/validate/jobs/{job_id}",
+    response_model=ValidationJobStatus,
+    responses={
+        200: {"description": "Status for an async validation job"},
+        404: {"description": "Job not found", "model": ErrorResponse},
+    },
+)
+async def get_validation_job(job_id: str):
+    """
+    Get status for an asynchronous validation job (issue #64).
+
+    When status is 'completed', the response includes the ValidationResult in 'result'.
+    """
+    job = _validation_jobs.get(job_id)
+    if not job:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "detail": f"Validation job not found: {job_id}",
+                "code": "JOB_NOT_FOUND",
+            },
+        )
+    return ValidationJobStatus(**job)
 
 
 @router.get(


### PR DESCRIPTION
## Summary

This PR implements **issue #64** by adding **asynchronous validation jobs** and a **status polling API** on top of the LangGraph-based validation workflow.

- Adds a `/validate/async` endpoint that queues a validation job and returns immediately with a `job_id`.
- Adds a `/validate/jobs/{job_id}` endpoint for polling job status and, when complete, retrieving the `ValidationResult`.
- Keeps existing synchronous `/validate` endpoints intact so the frontend can opt in to async behaviour.

---

## Related Issues

- **Closes #64** – Async/task-based execution with status polling
- **Parent epic:** #6 – LangGraph workflow implementation
- **Builds on:**
  - #60 – ValidationState and shared state schema
  - #61 – StateGraph with validation nodes and edges
  - #62 – Conditional routing by severity (critical → apply_corrections, else END)
  - #63 – Expose LangGraph workflow via synchronous validate endpoints

---

## Changes

### 1. Models (`backend/api/models.py`)

- **`ValidationJobStatus`** (new):
  - `job_id: str` – unique ID for the validation job
  - `dataset_id: str` – dataset being validated
  - `status: str` – `"pending" | "running" | "completed" | "failed"`
  - `error: Optional[str]` – error message if the job failed
  - `result: Optional[ValidationResult]` – full validation result when `status == "completed"`

Existing models (`GeometryIssue`, `ValidationResult`, `ValidateRequest`, `ErrorResponse`) are unchanged.

### 2. Routes (`backend/api/routes.py`)

- **In-memory job store**
  - Added `_validation_jobs: dict[str, dict] = {}` at module level to track async job state.

- **`POST /validate/async` – `validate_dataset_async` (new)**
  - Validates that the dataset exists using `get_primary_vector_path`.
  - Creates a `job_id = uuid.uuid4()` and stores an entry in `_validation_jobs`:
    - `status = "pending"`, `error = None`, `result = None`.
  - Schedules a background task (`BackgroundTasks`) that:
    - Marks the job as `"running"`.
    - Builds an initial LangGraph state via `empty_state(dataset_id, str(path))`.
    - Invokes `validation_graph.invoke(state)`.
    - Extracts `issues` from the final state and populates `result = ValidationResult(...)`.
    - Sets `status = "completed"` on success.
    - On exception, sets `status = "failed"` and stores the error message.
  - Returns an initial `ValidationJobStatus` with `status="pending"` and `result=None`.

- **`GET /validate/jobs/{job_id}` – `get_validation_job` (new)**
  - Looks up the job in `_validation_jobs`.
  - If not found: returns `404` with `code="JOB_NOT_FOUND"`.
  - If found: returns `ValidationJobStatus(**job)`.
  - When `status == "completed"`, the `result` field contains the `ValidationResult` that the synchronous `/validate` endpoint would have returned.

- **Existing endpoints** (`POST /validate` and `GET /validate/{dataset_id}`)
  - Remain unchanged from issue #63: they synchronously invoke `validation_graph` and return a `ValidationResult`.
  - Frontend can continue to use them unchanged or migrate to the async flow as desired.

---

## Behaviour and Frontend Integration

### Async flow

1. **Start validation:**
   - `POST /api/v1/validate/async` with body `{ "dataset_id": "<id>" }`.
   - Response (example):
     ```json
     {
       "job_id": "c0f3e4e2-...",
       "dataset_id": "<id>",
       "status": "pending",
       "error": null,
       "result": null
     }
     ```

2. **Poll status:**
   - `GET /api/v1/validate/jobs/{job_id}`.
   - While the job is running, `status` is `"pending"` or `"running"` and `result` is `null`.
   - When complete, `status` is `"completed"` and `result` contains a `ValidationResult` (same shape as the current synchronous endpoints).
   - If something goes wrong, `status` is `"failed"` and `error` contains a message.

3. **Frontend mapping (ties into existing props):**
   - `handleValidate` can be updated to call `/validate/async` and store `job_id`.
   - `isValidating` can be driven by `status` (`pending`/`running` vs `completed`/`failed`).
   - `validationResult` can be populated from `result` once `status == "completed"`.

### Synchronous flow

- The existing synchronous `/validate` endpoints are still available and fully functional, so the async path is purely opt-in.

---

## Verification

- **Linter:** No new linter issues in `api/models.py` or `api/routes.py`.
- **Tests:** All backend tests pass (`pytest tests/`).
- **Manual check:**
  - Async job creation and status polling exercised via direct invocation; job transitions through `pending` → `running` → `completed` and returns a `ValidationResult` with the expected `issues`.

---

## Future Enhancements

- Persist jobs to a durable store (e.g. Redis or database) instead of the in-memory `_validation_jobs` dict.
- Add optional progress information (e.g. per-agent status) to `ValidationJobStatus`.
- Extend the frontend to use `/validate/async` and `/validate/jobs/{job_id}` and surface richer progress UI.

Closes #64
