### PR TITLE
feat(#74): Extract and sample attribute data for LLM

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -31,6 +31,10 @@ class Settings(BaseSettings):
     # Checks: null/empty geometry, invalid geometry, self-intersection (see core.validation)
     GEOMETRY_VALIDATION_ENABLED: bool = True
 
+    # Attribute extraction for LLM (issue #74): max rows sampled from dataset
+    # Higher = better coverage, more tokens/cost. Default 500 balances both.
+    ATTRIBUTE_SAMPLE_SIZE: int = 500
+
     # Allowed geospatial file extensions (lowercase)
     ALLOWED_EXTENSIONS: List[str] = [
         ".shp",

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,1 +1,1 @@
-# Services: file_handler, arcgis_service, llm_service
+# Services: file_handler, arcgis_service, llm_service, attribute_extractor (issue #74)

--- a/backend/services/attribute_extractor.py
+++ b/backend/services/attribute_extractor.py
@@ -1,0 +1,146 @@
+"""
+Extract and sample attribute data from vector datasets for LLM-based validation (issue #74).
+
+Provides two representations:
+- Per-feature records: list of dicts (feature_id + attribute columns), for cross-feature consistency.
+- Per-field value lists: dict of column name -> list of values, for outlier/typo analysis per field.
+
+Sampling limits row count to control token usage and cost; geometry is never included in output.
+
+Trade-offs and defaults:
+- Default sample size is 500 (DEFAULT_ATTRIBUTE_SAMPLE_SIZE). Callers can pass sample_size or use
+  backend.core.config.settings.ATTRIBUTE_SAMPLE_SIZE for a configurable default.
+- Larger sample_size improves coverage (more features seen by the LLM) but increases tokens and cost.
+- Use random_state for reproducible runs (e.g. in tests or repeat validations).
+"""
+from typing import Any, Dict, List, Optional, Union
+
+import geopandas as gpd
+import pandas as pd
+
+
+# Default sample size when not specified (balance coverage vs token cost for GPT-4).
+DEFAULT_ATTRIBUTE_SAMPLE_SIZE = 500
+
+
+def _get_feature_id(row: pd.Series, idx: Any) -> Any:
+    """Use 'id' column if present, else index (aligned with core.validation)."""
+    if "id" in row.index:
+        try:
+            return row["id"]
+        except Exception:
+            pass
+    return idx
+
+
+def get_attribute_records(
+    gdf: gpd.GeoDataFrame,
+    sample_size: Optional[int] = None,
+    random_state: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Extract attribute data as a list of per-feature records (no geometry).
+
+    Each record is a dict with "feature_id" and all attribute column names as keys.
+    Use for LLM prompts that need row-level context (e.g. consistency across features).
+
+    Args:
+        gdf: GeoDataFrame (geometry column is dropped).
+        sample_size: Max number of rows to return. If None, uses DEFAULT_ATTRIBUTE_SAMPLE_SIZE.
+        random_state: Seed for reproducible sampling.
+
+    Returns:
+        List of dicts; each dict has feature_id and attribute key-value pairs.
+    """
+    if gdf is None or gdf.empty:
+        return []
+
+    n = sample_size if sample_size is not None else DEFAULT_ATTRIBUTE_SAMPLE_SIZE
+    # Drop geometry so we don't send WKB/WKT to the LLM
+    geom_col = gdf.geometry.name if hasattr(gdf, "geometry") and gdf.geometry is not None else None
+    cols = [c for c in gdf.columns if c != geom_col]
+    if not cols:
+        return []
+
+    df = gdf[cols].copy()
+    if len(df) > n:
+        df = df.sample(n=n, random_state=random_state)
+
+    records: List[Dict[str, Any]] = []
+    for idx, row in df.iterrows():
+        feature_id = _get_feature_id(row, idx)
+        rec: Dict[str, Any] = {"feature_id": feature_id}
+        for c in cols:
+            val = row[c]
+            rec[c] = val.item() if hasattr(val, "item") and callable(getattr(val, "item")) else val
+        records.append(rec)
+    return records
+
+
+def get_attribute_columns(
+    gdf: gpd.GeoDataFrame,
+    sample_size: Optional[int] = None,
+    random_state: Optional[int] = None,
+) -> Dict[str, List[Any]]:
+    """
+    Extract attribute data as per-field value lists (no geometry).
+
+    Result is {column_name: [val1, val2, ...]}. Use for LLM prompts that analyze
+    one field at a time (e.g. outliers, naming variations, missing values).
+
+    Args:
+        gdf: GeoDataFrame (geometry column is dropped).
+        sample_size: Max number of rows per column. If None, uses DEFAULT_ATTRIBUTE_SAMPLE_SIZE.
+        random_state: Seed for reproducible sampling.
+
+    Returns:
+        Dict mapping each attribute column name to a list of values (sampled).
+    """
+    if gdf is None or gdf.empty:
+        return {}
+
+    n = sample_size if sample_size is not None else DEFAULT_ATTRIBUTE_SAMPLE_SIZE
+    geom_col = gdf.geometry.name if hasattr(gdf, "geometry") and gdf.geometry is not None else None
+    cols = [c for c in gdf.columns if c != geom_col]
+    if not cols:
+        return {}
+
+    df = gdf[cols].copy()
+    if len(df) > n:
+        df = df.sample(n=n, random_state=random_state)
+
+    out: Dict[str, List[Any]] = {}
+    for c in cols:
+        vals = df[c].tolist()
+        out[c] = [v.item() if hasattr(v, "item") and callable(getattr(v, "item")) else v for v in vals]
+    return out
+
+
+def load_attributes_from_path(
+    path: Union[str, "pd.PathLike"],
+    sample_size: Optional[int] = None,
+    random_state: Optional[int] = None,
+    as_records: bool = True,
+) -> Union[List[Dict[str, Any]], Dict[str, List[Any]]]:
+    """
+    Load a vector dataset from path and return attribute data (no geometry).
+
+    Convenience helper for the attribute agent: read file once, return sampled attributes.
+
+    Args:
+        path: Path to GeoJSON, shapefile, etc. (GeoPandas read_file).
+        sample_size: Max rows to include (default DEFAULT_ATTRIBUTE_SAMPLE_SIZE).
+        random_state: Seed for sampling.
+        as_records: If True, return list of per-feature dicts; else per-field value lists.
+
+    Returns:
+        get_attribute_records(...) if as_records else get_attribute_columns(...).
+        Empty list or dict if file cannot be read.
+    """
+    try:
+        gdf = gpd.read_file(path)
+    except Exception:
+        return [] if as_records else {}
+    if as_records:
+        return get_attribute_records(gdf, sample_size=sample_size, random_state=random_state)
+    return get_attribute_columns(gdf, sample_size=sample_size, random_state=random_state)

--- a/backend/tests/test_attribute_extractor.py
+++ b/backend/tests/test_attribute_extractor.py
@@ -1,0 +1,111 @@
+"""Tests for services.attribute_extractor (issue #74)."""
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from services.attribute_extractor import (
+    DEFAULT_ATTRIBUTE_SAMPLE_SIZE,
+    get_attribute_columns,
+    get_attribute_records,
+    load_attributes_from_path,
+)
+
+
+def _gdf_with_attrs(n_rows: int, with_id_col: bool = False):
+    gdf = gpd.GeoDataFrame(
+        {"name": [f"f{i}" for i in range(n_rows)], "value": list(range(n_rows))},
+        geometry=[Point(i, i) for i in range(n_rows)],
+    )
+    if with_id_col:
+        gdf["id"] = [100 + i for i in range(n_rows)]
+    return gdf
+
+
+def test_get_attribute_records_no_geometry():
+    """Output has no geometry key and only attribute columns."""
+    gdf = _gdf_with_attrs(3)
+    records = get_attribute_records(gdf, sample_size=10)
+    assert len(records) == 3
+    for r in records:
+        assert "geometry" not in r
+        assert "feature_id" in r
+        assert "name" in r
+        assert "value" in r
+
+
+def test_get_attribute_records_respects_sample_size():
+    """Sampling caps number of rows returned."""
+    gdf = _gdf_with_attrs(200)
+    records = get_attribute_records(gdf, sample_size=50, random_state=42)
+    assert len(records) == 50
+
+
+def test_get_attribute_records_uses_index_as_feature_id():
+    """feature_id is the DataFrame index when no 'id' column."""
+    gdf = _gdf_with_attrs(2)
+    gdf.index = [7, 8]
+    records = get_attribute_records(gdf, sample_size=10)
+    fid_set = {r["feature_id"] for r in records}
+    assert fid_set == {7, 8}
+
+
+def test_get_attribute_records_uses_id_column_when_present():
+    """feature_id is from 'id' column when present."""
+    gdf = _gdf_with_attrs(2, with_id_col=True)
+    records = get_attribute_records(gdf, sample_size=10)
+    fid_set = {r["feature_id"] for r in records}
+    assert fid_set == {100, 101}
+
+
+def test_get_attribute_columns_no_geometry():
+    """Per-field output has no geometry column."""
+    gdf = _gdf_with_attrs(3)
+    cols = get_attribute_columns(gdf, sample_size=10)
+    assert "geometry" not in cols
+    assert "name" in cols
+    assert "value" in cols
+    assert len(cols["name"]) == 3
+
+
+def test_get_attribute_columns_respects_sample_size():
+    """Sampling caps number of values per column."""
+    gdf = _gdf_with_attrs(200)
+    cols = get_attribute_columns(gdf, sample_size=50, random_state=42)
+    assert len(cols["name"]) == 50
+    assert len(cols["value"]) == 50
+
+
+def test_empty_gdf_returns_empty():
+    """Empty GeoDataFrame returns empty list/dict."""
+    gdf = gpd.GeoDataFrame(geometry=[])
+    assert get_attribute_records(gdf) == []
+    assert get_attribute_columns(gdf) == {}
+
+
+def test_default_sample_size_used():
+    """When sample_size is None, default caps rows."""
+    gdf = _gdf_with_attrs(DEFAULT_ATTRIBUTE_SAMPLE_SIZE + 100)
+    records = get_attribute_records(gdf, random_state=0)
+    assert len(records) == DEFAULT_ATTRIBUTE_SAMPLE_SIZE
+
+
+def test_load_attributes_from_path_as_records(tmp_path):
+    """load_attributes_from_path with as_records returns list of dicts."""
+    gdf = _gdf_with_attrs(2)
+    path = tmp_path / "test.geojson"
+    gdf.to_file(path, driver="GeoJSON")
+    out = load_attributes_from_path(path, sample_size=10, as_records=True)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert all("feature_id" in r and "geometry" not in r for r in out)
+
+
+def test_load_attributes_from_path_as_columns(tmp_path):
+    """load_attributes_from_path with as_records=False returns per-field dict."""
+    gdf = _gdf_with_attrs(2)
+    path = tmp_path / "test.geojson"
+    gdf.to_file(path, driver="GeoJSON")
+    out = load_attributes_from_path(path, sample_size=10, as_records=False)
+    assert isinstance(out, dict)
+    assert "geometry" not in out
+    assert "name" in out and len(out["name"]) == 2


### PR DESCRIPTION
## Summary
Implements **issue #74** ([#7] Extract and sample attribute data for LLM): attribute extraction and sampling for LLM-based validation, without sending geometry to the LLM.

## Changes

### New: `backend/services/attribute_extractor.py`
- **Per-feature records:** `get_attribute_records(gdf, sample_size=None, random_state=None)` → list of dicts with `feature_id` and attribute key-value pairs (no geometry).
- **Per-field value lists:** `get_attribute_columns(gdf, sample_size=None, random_state=None)` → `{column_name: [v1, v2, ...]}` for per-field analysis.
- **Sampling:** When `len(gdf) > sample_size`, rows are sampled via `gdf.sample(n=sample_size, random_state=random_state)`; default sample size 500.
- **Feature ID:** Aligned with `core.validation`: uses index or `"id"` column when present.
- **Convenience:** `load_attributes_from_path(path, ...)` loads with `gpd.read_file` and returns records or columns; returns empty list/dict on read error.

### Config
- **`backend/core/config.py`:** `ATTRIBUTE_SAMPLE_SIZE: int = 500` with comment on coverage vs token cost.

### Documentation
- Module docstring documents both representations and a **Trade-offs and defaults** section (default 500, coverage vs tokens/cost, `random_state` for reproducibility).

### Tests
- **`backend/tests/test_attribute_extractor.py`:** 10 tests covering no geometry in output, sampling cap, feature_id from index vs `"id"`, empty GDF, default sample size, and `load_attributes_from_path` for both formats.

## Acceptance criteria (issue #74)
- [x] Decide representation: per-feature records and per-field value lists (both implemented).
- [x] Implement helper(s) to extract attribute data from GeoDataFrame **without** geometry.
- [x] Implement sampling/limiting (cap rows, optional random_state).
- [x] Document trade-offs and defaults.

## Related issues
- Closes #74
- Part of #7