### PR TITLE
feat(#73): Implement Attribute Agent node (LLM-backed)

### DIFF
--- a/backend/agents/attribute_agent.py
+++ b/backend/agents/attribute_agent.py
@@ -1,11 +1,94 @@
-"""Attribute validation agent: consistency, outliers, missing values (LLM-assisted). Stub for #61."""
+"""
+Attribute validation agent: LLM-backed consistency, typos, outliers (issue #73).
+
+Uses services.attribute_extractor for sampled attribute data and services.llm_service
+for inconsistency detection. Appends attribute issues into state["issues"] using
+GeometryIssue-compatible structure (type=attribute_*, description=field + suggestion).
+"""
+from typing import Any, Dict, List, Optional
+
+import geopandas as gpd
+
+from api.models import GeometryIssue
 from agents.state import ValidationState
+from core.config import settings
+from services.attribute_extractor import get_attribute_columns, get_attribute_records
+from services.llm_service import (
+    AttributeIssue as LLMAttributeIssue,
+    SupportsInvoke,
+    validate_attributes_with_llm,
+)
 
 
-def run(state: ValidationState) -> dict:
+# Fixed random_state for deterministic sampling (issue #73: deterministic node).
+_ATTRIBUTE_SAMPLE_RANDOM_STATE = 0
+
+
+def _attribute_issue_to_geometry_issue(attr: Dict[str, Any]) -> GeometryIssue:
+    """Map an LLM attribute-issue dict to GeometryIssue for state["issues"]."""
+    field = attr.get("field") or ""
+    suggestion = attr.get("suggestion") or ""
+    issue_type = attr.get("issue_type") or "other"
+    severity = attr.get("severity") or "warning"
+    description = f"Field '{field}': {suggestion}".strip()
+    return GeometryIssue(
+        feature_id=attr.get("feature_id"),
+        type=f"attribute_{issue_type}",
+        severity=severity,
+        location=None,
+        description=description or None,
+    )
+
+
+def run(
+    state: ValidationState,
+    *,
+    sample_size: Optional[int] = None,
+    llm: Optional[SupportsInvoke] = None,
+) -> dict:
     """
-    Run attribute validation on the dataset in state.
-    Returns partial state update (e.g. {"issues": [...]}).
-    Stub: no-op until attribute validation is implemented.
+    Run attribute validation on the dataset in state (issue #73).
+
+    - Loads the dataset from state["dataset_path"] and extracts attribute samples
+      (no geometry) via services.attribute_extractor.
+    - Calls the LLM service for inconsistency detection.
+    - Converts results to GeometryIssue-like entries and appends them to state["issues"].
+
+    Deterministic: uses fixed random_state when sampling. Side-effect free apart from
+    the returned state update (no global state mutation).
+
+    Args:
+        state: Current validation state (dataset_path, issues, ...).
+        sample_size: Max rows to sample; default from settings.ATTRIBUTE_SAMPLE_SIZE.
+        llm: Optional LLM instance for testing; if None, default client is used.
+
+    Returns:
+        Partial state update: {"issues": existing_issues + new_attribute_issues}.
     """
-    return {}
+    existing = list(state.get("issues") or [])
+    path = state.get("dataset_path")
+    if not path:
+        return {"issues": existing}
+
+    try:
+        gdf = gpd.read_file(path)
+    except Exception:
+        return {"issues": existing}
+
+    if gdf is None or gdf.empty:
+        return {"issues": existing}
+
+    n = sample_size if sample_size is not None else settings.ATTRIBUTE_SAMPLE_SIZE
+    records = get_attribute_records(gdf, sample_size=n, random_state=_ATTRIBUTE_SAMPLE_RANDOM_STATE)
+    per_field = get_attribute_columns(gdf, sample_size=n, random_state=_ATTRIBUTE_SAMPLE_RANDOM_STATE)
+
+    if not records and not per_field:
+        return {"issues": existing}
+
+    raw_issues: List[LLMAttributeIssue] = validate_attributes_with_llm(
+        records,
+        per_field_values=per_field,
+        llm=llm,
+    )
+    new_issues = [_attribute_issue_to_geometry_issue(attr) for attr in raw_issues]
+    return {"issues": existing + new_issues}

--- a/backend/tests/test_attribute_agent.py
+++ b/backend/tests/test_attribute_agent.py
@@ -1,0 +1,107 @@
+"""Tests for agents.attribute_agent (issue #73)."""
+from pathlib import Path
+from unittest.mock import patch
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from agents.attribute_agent import run as attribute_agent_run
+
+
+def _minimal_geojson_path(tmp_path: Path) -> Path:
+    """Create a minimal GeoJSON with two point features and attribute columns."""
+    gdf = gpd.GeoDataFrame(
+        {"name": ["Main St", "Oak Ave"], "value": [1, 2]},
+        geometry=[Point(0, 0), Point(1, 1)],
+    )
+    path = tmp_path / "sample.geojson"
+    gdf.to_file(path, driver="GeoJSON")
+    return path
+
+
+def test_run_appends_attribute_issues_to_state(tmp_path):
+    """Attribute agent calls LLM service and appends GeometryIssue-like issues to state."""
+    path = _minimal_geojson_path(tmp_path)
+    state = {"dataset_id": "test", "dataset_path": str(path), "issues": []}
+
+    mock_issues = [
+        {
+            "feature_id": 0,
+            "field": "name",
+            "issue_type": "typo",
+            "severity": "warning",
+            "suggestion": "Use 'Main Street'",
+        }
+    ]
+
+    with patch("agents.attribute_agent.validate_attributes_with_llm", return_value=mock_issues):
+        result = attribute_agent_run(state)
+
+    assert "issues" in result
+    issues = result["issues"]
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue.feature_id == 0
+    assert issue.type == "attribute_typo"
+    assert issue.severity == "warning"
+    assert "name" in (issue.description or "")
+    assert "Main Street" in (issue.description or "")
+    assert issue.location is None
+
+
+def test_run_with_no_dataset_path_returns_existing_issues():
+    """When dataset_path is missing, return state with no new issues."""
+    state = {"dataset_id": "test", "dataset_path": None, "issues": []}
+    result = attribute_agent_run(state)
+    assert result["issues"] == []
+
+
+def test_run_with_invalid_path_returns_existing_issues():
+    """When path is invalid or unreadable, return existing issues only."""
+    state = {"dataset_id": "test", "dataset_path": "/nonexistent/file.geojson", "issues": []}
+    result = attribute_agent_run(state)
+    assert result["issues"] == []
+
+
+def test_run_preserves_existing_issues(tmp_path):
+    """New attribute issues are appended to existing geometry (or other) issues."""
+    path = _minimal_geojson_path(tmp_path)
+    from api.models import GeometryIssue
+
+    existing = [
+        GeometryIssue(feature_id=99, type="empty_geometry", severity="critical", location=None, description="Empty"),
+    ]
+    state = {"dataset_path": str(path), "issues": existing}
+
+    mock_issues = [
+        {"feature_id": 1, "field": "name", "issue_type": "inconsistency", "severity": "info", "suggestion": "Normalize"},
+    ]
+
+    with patch("agents.attribute_agent.validate_attributes_with_llm", return_value=mock_issues):
+        result = attribute_agent_run(state)
+
+    assert len(result["issues"]) == 2
+    assert result["issues"][0].feature_id == 99
+    assert result["issues"][0].type == "empty_geometry"
+    assert result["issues"][1].feature_id == 1
+    assert result["issues"][1].type == "attribute_inconsistency"
+
+
+def test_run_with_injected_llm_uses_it(tmp_path):
+    """Passing llm= uses that instance instead of default client."""
+    path = _minimal_geojson_path(tmp_path)
+    state = {"dataset_path": str(path), "issues": []}
+
+    class CapturingLLM:
+        def __init__(self):
+            self.invoked = False
+
+        def invoke(self, prompt: str, **kwargs):
+            self.invoked = True
+            return type("Msg", (), {"content": '{"issues": []}'})()
+
+    llm = CapturingLLM()
+    result = attribute_agent_run(state, llm=llm)
+    assert llm.invoked
+    assert result["issues"] == []


### PR DESCRIPTION
## Summary
Implements **issue #73** ([#7] Implement Attribute Agent node (LLM-backed)): the attribute validation node now extracts attribute samples, calls the LLM service, and appends structured attribute issues into shared validation state.

## Changes

### Updated: `backend/agents/attribute_agent.py`
- **`run(state, *, sample_size=None, llm=None)`**
  - Reads **dataset_path** from state; if missing, returns existing issues only.
  - Loads the dataset once with `gpd.read_file(path)` and gets attribute data via:
    - `services.attribute_extractor.get_attribute_records(gdf, sample_size, random_state=0)`
    - `services.attribute_extractor.get_attribute_columns(gdf, sample_size, random_state=0)`
  - Calls **`services.llm_service.validate_attributes_with_llm(records, per_field_values=per_field, llm=llm)`** for inconsistency detection.
  - Maps each LLM attribute issue to a **GeometryIssue**-compatible entry for `state["issues"]`:
    - **type:** `attribute_<issue_type>` (e.g. `attribute_typo`, `attribute_inconsistency`)
    - **description:** `Field '<field>': <suggestion>`
    - **location:** `None` (attribute issues have no geometry)
    - **feature_id**, **severity** from the LLM output.
  - Returns `{"issues": existing_issues + new_attribute_issues}`.
- **Determinism:** Uses fixed `random_state=0` when sampling so the node is deterministic aside from LLM non-determinism.
- **Side-effect free:** Only returns a state update; no global state or extra I/O beyond file read and LLM call.
- **Testability:** Optional **`llm`** argument lets tests inject a fake LLM; **`sample_size`** is optional (default from `settings.ATTRIBUTE_SAMPLE_SIZE`).

### New: `backend/tests/test_attribute_agent.py`
- **test_run_appends_attribute_issues_to_state** – Temp GeoJSON + mocked `validate_attributes_with_llm`; asserts one attribute issue becomes a GeometryIssue with `attribute_typo`, correct feature_id and description.
- **test_run_with_no_dataset_path_returns_existing_issues** – No path → no new issues.
- **test_run_with_invalid_path_returns_existing_issues** – Unreadable path → existing issues only.
- **test_run_preserves_existing_issues** – Existing geometry issue + mocked attribute issue → both present in returned state.
- **test_run_with_injected_llm_uses_it** – Passes a capturing fake LLM; asserts it is invoked and result shape is correct when LLM returns empty list.

## Acceptance criteria (issue #73)
- [x] Implement `agents/attribute_agent.py` so `run(state)` extracts attribute samples, calls the LLM service, and produces a structured list of attribute issues.
- [x] Append attribute issues into `state["issues"]` using a compatible structure (GeometryIssue with type=attribute_*, description=field + suggestion).
- [x] Node is deterministic (fixed random_state) and side-effect free apart from state updates.
- [x] Add basic unit tests with mocked LLM service.

## Related issues
- Closes #73
- Part of #7
- Builds on #71 (llm_service), #74 (attribute_extractor)