### PR TITLE
feat(#70): Token/cost optimization for attribute validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,25 @@ VITE_MAP_ZOOM_LEVEL=10
 - ~$0.01 - $0.05 per validation run (depending on dataset size)
 - Average thesis project: $5-20 total
 
+### **AI & LLM: token and cost optimization (attribute validation)**
+
+Attribute validation uses GPT-4 to detect inconsistencies, typos, and outliers. To keep token usage and cost manageable on large datasets, the following settings (in `backend/.env` or `core.config`) apply:
+
+| Setting | Default | Description |
+|--------|---------|-------------|
+| `ATTRIBUTE_SAMPLE_SIZE` | 500 | Max rows sampled from the dataset before sending to the LLM. |
+| `ATTRIBUTE_MAX_FIELDS` | (none) | If set, only the first N attribute columns are sent. Use for very wide tables. |
+| `ATTRIBUTE_MAX_RECORDS_IN_PROMPT` | 10 | Max records embedded in the prompt (subset of the sample). |
+| `ATTRIBUTE_MAX_VALUES_PER_FIELD` | 15 | Max values per field in the per-field summary. |
+| `OPENAI_MAX_TOKENS` | 2048 | Max tokens for the model response. |
+
+**Trade-offs:**
+- **Larger sample size** → better coverage (more features seen) but more tokens and cost. Default 500 balances coverage and cost.
+- **Smaller `ATTRIBUTE_MAX_RECORDS_IN_PROMPT` / `ATTRIBUTE_MAX_VALUES_PER_FIELD`** → smaller prompts and lower cost; the LLM sees less context per request.
+- **`ATTRIBUTE_MAX_FIELDS`** → reduces prompt size when the dataset has many columns; set to e.g. 20 to cap the number of fields analyzed per run.
+
+**Rough token estimates:** A naive prompt sending 10,000 rows × 5 fields could be on the order of 100k+ input tokens. With defaults (500-row sample, 10 records in prompt, 15 values per field), the input is typically **~2k–5k tokens** per attribute-validation request. Use `services.attribute_llm_cost.estimate_attribute_prompt_tokens` and `estimate_naive_tokens` for your own dataset dimensions.
+
 ---
 
 ## 💻 Usage

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,14 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 MAX_UPLOAD_SIZE_MB=50
 UPLOAD_DIR=./uploads
 OUTPUT_DIR=./outputs
+
+# Attribute validation – sampling and token/cost (issue #70)
+ATTRIBUTE_SAMPLE_SIZE=500
+ATTRIBUTE_MAX_FIELDS=
+ATTRIBUTE_MAX_RECORDS_IN_PROMPT=10
+ATTRIBUTE_MAX_VALUES_PER_FIELD=15
+
+# LLM (OpenAI) – attribute validation
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_MAX_TOKENS=2048

--- a/backend/agents/attribute_agent.py
+++ b/backend/agents/attribute_agent.py
@@ -79,8 +79,13 @@ def run(
         return {"issues": existing}
 
     n = sample_size if sample_size is not None else settings.ATTRIBUTE_SAMPLE_SIZE
-    records = get_attribute_records(gdf, sample_size=n, random_state=_ATTRIBUTE_SAMPLE_RANDOM_STATE)
-    per_field = get_attribute_columns(gdf, sample_size=n, random_state=_ATTRIBUTE_SAMPLE_RANDOM_STATE)
+    max_fields = getattr(settings, "ATTRIBUTE_MAX_FIELDS", None)
+    records = get_attribute_records(
+        gdf, sample_size=n, random_state=_ATTRIBUTE_SAMPLE_RANDOM_STATE, max_fields=max_fields
+    )
+    per_field = get_attribute_columns(
+        gdf, sample_size=n, random_state=_ATTRIBUTE_SAMPLE_RANDOM_STATE, max_fields=max_fields
+    )
 
     if not records and not per_field:
         return {"issues": existing}

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -31,9 +31,17 @@ class Settings(BaseSettings):
     # Checks: null/empty geometry, invalid geometry, self-intersection (see core.validation)
     GEOMETRY_VALIDATION_ENABLED: bool = True
 
-    # Attribute extraction for LLM (issue #74): max rows sampled from dataset
+    # Attribute extraction for LLM (issue #74, #70): max rows sampled from dataset
     # Higher = better coverage, more tokens/cost. Default 500 balances both.
     ATTRIBUTE_SAMPLE_SIZE: int = 500
+
+    # Token/cost optimization (issue #70): limit data sent per request
+    # Max attribute columns to include (None = all). Reduces prompt size for wide tables.
+    ATTRIBUTE_MAX_FIELDS: int | None = None
+    # Max records embedded in the prompt (subset of sample). Lower = cheaper, less context.
+    ATTRIBUTE_MAX_RECORDS_IN_PROMPT: int = 10
+    # Max values per field in the per-field summary. Lower = smaller prompt.
+    ATTRIBUTE_MAX_VALUES_PER_FIELD: int = 15
 
     # LLM / GPT-4 configuration for attribute validation (issue #71)
     # API key is read from OPENAI_API_KEY env var by default; model can be overridden.

--- a/backend/services/attribute_extractor.py
+++ b/backend/services/attribute_extractor.py
@@ -37,6 +37,7 @@ def get_attribute_records(
     gdf: gpd.GeoDataFrame,
     sample_size: Optional[int] = None,
     random_state: Optional[int] = None,
+    max_fields: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """
     Extract attribute data as a list of per-feature records (no geometry).
@@ -48,6 +49,7 @@ def get_attribute_records(
         gdf: GeoDataFrame (geometry column is dropped).
         sample_size: Max number of rows to return. If None, uses DEFAULT_ATTRIBUTE_SAMPLE_SIZE.
         random_state: Seed for reproducible sampling.
+        max_fields: If set, only the first N attribute columns are included (issue #70).
 
     Returns:
         List of dicts; each dict has feature_id and attribute key-value pairs.
@@ -59,6 +61,8 @@ def get_attribute_records(
     # Drop geometry so we don't send WKB/WKT to the LLM
     geom_col = gdf.geometry.name if hasattr(gdf, "geometry") and gdf.geometry is not None else None
     cols = [c for c in gdf.columns if c != geom_col]
+    if max_fields is not None and max_fields > 0:
+        cols = cols[:max_fields]
     if not cols:
         return []
 
@@ -81,6 +85,7 @@ def get_attribute_columns(
     gdf: gpd.GeoDataFrame,
     sample_size: Optional[int] = None,
     random_state: Optional[int] = None,
+    max_fields: Optional[int] = None,
 ) -> Dict[str, List[Any]]:
     """
     Extract attribute data as per-field value lists (no geometry).
@@ -92,6 +97,7 @@ def get_attribute_columns(
         gdf: GeoDataFrame (geometry column is dropped).
         sample_size: Max number of rows per column. If None, uses DEFAULT_ATTRIBUTE_SAMPLE_SIZE.
         random_state: Seed for reproducible sampling.
+        max_fields: If set, only the first N attribute columns (issue #70).
 
     Returns:
         Dict mapping each attribute column name to a list of values (sampled).
@@ -102,6 +108,8 @@ def get_attribute_columns(
     n = sample_size if sample_size is not None else DEFAULT_ATTRIBUTE_SAMPLE_SIZE
     geom_col = gdf.geometry.name if hasattr(gdf, "geometry") and gdf.geometry is not None else None
     cols = [c for c in gdf.columns if c != geom_col]
+    if max_fields is not None and max_fields > 0:
+        cols = cols[:max_fields]
     if not cols:
         return {}
 

--- a/backend/services/attribute_llm_cost.py
+++ b/backend/services/attribute_llm_cost.py
@@ -1,0 +1,76 @@
+"""
+Token and cost estimation for attribute validation LLM calls (issue #70).
+
+Provides rough input-token estimates for attribute prompts so callers can reason about
+cost and tune ATTRIBUTE_SAMPLE_SIZE / ATTRIBUTE_MAX_RECORDS_IN_PROMPT / etc.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+
+# Approximate characters per token for English/JSON (OpenAI ~4, conservative).
+CHARS_PER_TOKEN = 4
+
+
+def estimate_attribute_prompt_tokens(
+    attribute_records: List[Dict[str, Any]],
+    per_field_values: Optional[Dict[str, List[Any]]] = None,
+    *,
+    max_records_in_prompt: int = 10,
+    max_values_per_field: int = 15,
+    max_fields: Optional[int] = None,
+) -> int:
+    """
+    Estimate input token count for the attribute validation prompt.
+
+    Uses the same slicing as build_attribute_validation_prompt (records and
+    per_field truncated) plus a fixed instruction size. Useful for comparing
+    naive (full dataset) vs optimized (sampled + truncated) usage.
+
+    Args:
+        attribute_records: Full or sampled records (only first max_records_in_prompt used).
+        per_field_values: Full or sampled per-field lists (sliced by max_*).
+        max_records_in_prompt: Same as ATTRIBUTE_MAX_RECORDS_IN_PROMPT.
+        max_values_per_field: Same as ATTRIBUTE_MAX_VALUES_PER_FIELD.
+        max_fields: Same as ATTRIBUTE_MAX_FIELDS (None = all fields).
+
+    Returns:
+        Approximate number of input tokens (instruction + ATTRIBUTE_DATA JSON).
+    """
+    # Instruction block is ~600 chars in current prompt
+    instruction_chars = 600
+    pf = per_field_values or {}
+    if max_fields is not None and max_fields > 0:
+        keys = list(pf.keys())[:max_fields]
+        pf = {k: pf[k][:max_values_per_field] for k in keys if k in pf}
+    else:
+        pf = {k: v[:max_values_per_field] for k, v in pf.items()}
+    examples = {
+        "records": attribute_records[:max_records_in_prompt],
+        "per_field_values": pf,
+    }
+    data_str = json.dumps(examples, default=str)
+    total_chars = instruction_chars + len(data_str)
+    return max(0, (total_chars + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN)
+
+
+def estimate_naive_tokens(num_rows: int, num_fields: int, avg_chars_per_value: int = 15) -> int:
+    """
+    Rough estimate for a naive prompt that sent all rows and all fields.
+
+    Use to compare against optimized (sampled + truncated) token usage.
+
+    Args:
+        num_rows: Total feature count.
+        num_fields: Attribute column count.
+        avg_chars_per_value: Approximate characters per cell when serialized.
+
+    Returns:
+        Approximate input tokens for a naive full-dataset prompt.
+    """
+    # One record ≈ feature_id + num_fields * avg value
+    chars_per_record = 20 + num_fields * avg_chars_per_value
+    total_chars = 600 + num_rows * chars_per_record
+    return max(0, (total_chars + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN)

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -74,22 +74,43 @@ def _default_llm(config: Optional[AttributeValidationConfig] = None) -> Supports
 def build_attribute_validation_prompt(
     attribute_records: List[Dict[str, Any]],
     per_field_values: Optional[Dict[str, List[Any]]] = None,
+    *,
+    max_records_in_prompt: Optional[int] = None,
+    max_values_per_field: Optional[int] = None,
+    max_fields: Optional[int] = None,
 ) -> str:
     """
-    Build a prompt for GPT-4 to detect attribute issues.
+    Build a prompt for GPT-4 to detect attribute issues (issue #70: token limits).
+
+    Uses settings.ATTRIBUTE_MAX_RECORDS_IN_PROMPT and ATTRIBUTE_MAX_VALUES_PER_FIELD
+    when the optional limits are not provided, to keep prompt size and cost manageable.
 
     Args:
         attribute_records: List of per-feature dicts, usually including \"feature_id\" and
             attribute columns (from services.attribute_extractor.get_attribute_records).
         per_field_values: Optional mapping of field -> list of values across features
             (from get_attribute_columns), useful for outlier / distribution analysis.
+        max_records_in_prompt: Cap on records embedded in prompt; default from settings.
+        max_values_per_field: Cap on values per field in prompt; default from settings.
+        max_fields: If set, only first N fields in per_field_values; default from settings.
 
     Returns:
         A string prompt instructing the model to return JSON with an \"issues\" list.
     """
+    n_rec = max_records_in_prompt if max_records_in_prompt is not None else getattr(
+        settings, "ATTRIBUTE_MAX_RECORDS_IN_PROMPT", 10
+    )
+    n_val = max_values_per_field if max_values_per_field is not None else getattr(
+        settings, "ATTRIBUTE_MAX_VALUES_PER_FIELD", 15
+    )
+    n_fld = max_fields if max_fields is not None else getattr(settings, "ATTRIBUTE_MAX_FIELDS", None)
+    pf = per_field_values or {}
+    if n_fld is not None and n_fld > 0:
+        keys = list(pf.keys())[:n_fld]
+        pf = {k: pf[k] for k in keys if k in pf}
     examples = {
-        "records": attribute_records[:5],
-        "per_field_values": {k: v[:10] for k, v in (per_field_values or {}).items()},
+        "records": attribute_records[:n_rec],
+        "per_field_values": {k: v[:n_val] for k, v in pf.items()},
     }
     instructions = (
         "You are a geospatial data quality assistant. "

--- a/backend/tests/test_attribute_extractor.py
+++ b/backend/tests/test_attribute_extractor.py
@@ -109,3 +109,15 @@ def test_load_attributes_from_path_as_columns(tmp_path):
     assert isinstance(out, dict)
     assert "geometry" not in out
     assert "name" in out and len(out["name"]) == 2
+
+
+def test_get_attribute_records_respects_max_fields():
+    """max_fields limits number of attribute columns (issue #70)."""
+    gdf = gpd.GeoDataFrame(
+        {"a": [1], "b": [2], "c": [3]},
+        geometry=[Point(0, 0)],
+    )
+    records = get_attribute_records(gdf, sample_size=10, max_fields=2)
+    assert len(records) == 1
+    assert "a" in records[0] and "b" in records[0]
+    assert "c" not in records[0]

--- a/backend/tests/test_attribute_llm_cost.py
+++ b/backend/tests/test_attribute_llm_cost.py
@@ -1,0 +1,29 @@
+"""Tests for services.attribute_llm_cost (issue #70)."""
+import pytest
+
+from services.attribute_llm_cost import (
+    estimate_attribute_prompt_tokens,
+    estimate_naive_tokens,
+)
+
+
+def test_estimate_attribute_prompt_tokens_small():
+    """Optimized prompt estimate is bounded by limits."""
+    records = [{"feature_id": i, "name": f"r{i}", "val": i} for i in range(100)]
+    per_field = {"name": ["a", "b"] * 50, "val": list(range(100))}
+    tokens = estimate_attribute_prompt_tokens(
+        records,
+        per_field,
+        max_records_in_prompt=10,
+        max_values_per_field=15,
+    )
+    assert tokens > 0
+    assert tokens < 5000
+
+
+def test_estimate_naive_tokens():
+    """Naive estimate scales with rows and fields."""
+    small = estimate_naive_tokens(100, 5)
+    large = estimate_naive_tokens(10000, 10)
+    assert large > small
+    assert small > 0


### PR DESCRIPTION
## Summary
Implements **issue #70** ([#7] Token/cost optimization for attribute validation): configurable limits and token estimation so GPT-4 attribute validation stays manageable on large or wide datasets.

## Changes

### Config (`backend/core/config.py`)
- **ATTRIBUTE_MAX_FIELDS** (`int | None = None`) – Cap on how many attribute columns are sent. Use for very wide tables (e.g. set to 20).
- **ATTRIBUTE_MAX_RECORDS_IN_PROMPT** (`int = 10`) – Max records embedded in the prompt (subset of the sample).
- **ATTRIBUTE_MAX_VALUES_PER_FIELD** (`int = 15`) – Max values per field in the per-field summary.

### Sampling and prompt limits
- **`services/attribute_extractor.py`** – `get_attribute_records` and `get_attribute_columns` accept optional **max_fields**; when set, only the first N attribute columns are included.
- **`services/llm_service.py`** – `build_attribute_validation_prompt` uses the new settings (or overrides) to slice records and per-field values and to limit fields when ATTRIBUTE_MAX_FIELDS is set.
- **`agents/attribute_agent.py`** – Passes `settings.ATTRIBUTE_MAX_FIELDS` into the extractor so the agent respects the field limit.

### Token estimation (`backend/services/attribute_llm_cost.py`)
- **estimate_attribute_prompt_tokens(...)** – Approximate input token count for the current prompt (same slicing as the real prompt).
- **estimate_naive_tokens(num_rows, num_fields, avg_chars_per_value)** – Rough estimate if the full dataset were sent, for comparison with optimized usage.

### Documentation
- **README.md** – New subsection **"AI & LLM: token and cost optimization (attribute validation)"** with a settings table, trade-offs, and rough token estimates (naive vs optimized).
- **backend/.env.example** – Commented examples for the new attribute and LLM-related env vars.

### Tests
- **test_attribute_extractor.py** – `test_get_attribute_records_respects_max_fields` (max_fields limits columns).
- **test_attribute_llm_cost.py** – Tests for `estimate_attribute_prompt_tokens` and `estimate_naive_tokens`.

## Acceptance criteria (issue #70)
- [x] Analyze common dataset sizes and estimate token usage for naive attribute prompts (estimate_naive_tokens + README estimates).
- [x] Implement sampling/batching strategies (existing row sampling + per-field and per-prompt limits; optional max_fields).
- [x] Add configuration options (env/settings) for sampling size and max tokens per request.
- [x] Document recommended defaults and trade-offs in README.

## Related issues
- Closes #70
- Part of #7
- Builds on #71 (llm_service), #73 (attribute agent), #74 (attribute_extractor)