### PR TITLE
feat(#80): Topology validation logic (gaps, overlaps, dangles)

### DIFF
--- a/backend/core/topology.py
+++ b/backend/core/topology.py
@@ -1,0 +1,285 @@
+"""
+Topology validation: gaps, overlaps, connectivity (issue #80).
+
+Detects spatial relationship violations using GeoPandas/Shapely. Returns a list
+of violation dicts (feature_id, type, severity, location, description) suitable
+for conversion to GeometryIssue.
+
+Assumptions:
+- Geometries are in a projected or geographic CRS; operations use Shapely (planar).
+- Gaps/overlaps: intended for polygon layers; invalid or empty geometries are skipped.
+- Connectivity: intended for LineString layers; detects dangles (endpoints not touching another line).
+
+Limitations:
+- Large datasets: pair-wise overlap check is O(n^2); consider spatial index and tolerance.
+- ArcGIS-specific rules are not implemented; can be added later via optional ArcGIS API.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import geopandas as gpd
+from shapely.geometry import LineString, Point, Polygon
+from shapely.geometry.base import BaseGeometry
+from shapely.ops import unary_union
+
+
+# Topology issue type constants (prefix topology_ for consistency with attribute_*)
+class TopologyIssueType:
+    GAP = "topology_gap"
+    OVERLAP = "topology_overlap"
+    DANGLE = "topology_dangle"  # disconnected endpoint
+
+
+class Severity:
+    CRITICAL = "critical"
+    WARNING = "warning"
+
+
+def _location(geom: BaseGeometry) -> Optional[List[float]]:
+    """Return [x, y] for map display, or None."""
+    if geom is None or getattr(geom, "is_empty", True):
+        return None
+    try:
+        pt = getattr(geom, "centroid", None) or getattr(geom, "representative_point", lambda: None)()
+        if pt is not None and not getattr(pt, "is_empty", True):
+            return [float(pt.x), float(pt.y)]
+    except Exception:
+        pass
+    try:
+        b = getattr(geom, "bounds", None)
+        if b is not None and len(b) >= 4:
+            return [float(b[0] + b[2]) / 2, float(b[1] + b[3]) / 2]
+    except Exception:
+        pass
+    return None
+
+
+def _get_feature_id(gdf: gpd.GeoDataFrame, idx: Any) -> Any:
+    """Use 'id' column if present, else index (aligned with core.validation)."""
+    if "id" in gdf.columns:
+        try:
+            return gdf.loc[idx, "id"]
+        except Exception:
+            pass
+    return idx
+
+
+def _valid_polygons(gdf: gpd.GeoDataFrame):
+    """Yield (index, geometry) for valid non-empty polygon geometries."""
+    for idx, geom in gdf.geometry.items():
+        if geom is None or geom.is_empty:
+            continue
+        if not hasattr(geom, "exterior"):  # Polygon-like
+            continue
+        try:
+            if geom.is_valid and not geom.is_empty:
+                yield idx, geom
+        except Exception:
+            continue
+
+
+def _detect_gaps(gdf: gpd.GeoDataFrame) -> List[Dict[str, Any]]:
+    """
+    Detect gaps (holes in polygon coverage) using unary_union.
+    Each hole in the union is reported as a gap. feature_id is None (gap between features).
+    """
+    issues: List[Dict[str, Any]] = []
+    geoms = [geom for _, geom in _valid_polygons(gdf)]
+    if len(geoms) < 1:
+        return issues
+    try:
+        union = unary_union(geoms)
+        if union is None or union.is_empty:
+            return issues
+        # Collect interiors (holes) from the union
+        if hasattr(union, "interiors"):
+            for ring in union.interiors:
+                try:
+                    hole = Polygon(ring)
+                    if not hole.is_empty:
+                        loc = _location(hole)
+                        issues.append({
+                            "feature_id": None,
+                            "other_feature_id": None,
+                            "type": TopologyIssueType.GAP,
+                            "severity": Severity.WARNING,
+                            "location": loc,
+                            "description": "Gap in polygon coverage",
+                        })
+                except Exception:
+                    continue
+        elif hasattr(union, "geoms"):
+            for poly in union.geoms:
+                if hasattr(poly, "interiors"):
+                    for ring in poly.interiors:
+                        try:
+                            hole = Polygon(ring)
+                            if not hole.is_empty:
+                                loc = _location(hole)
+                                issues.append({
+                                    "feature_id": None,
+                                    "other_feature_id": None,
+                                    "type": TopologyIssueType.GAP,
+                                    "severity": Severity.WARNING,
+                                    "location": loc,
+                                    "description": "Gap in polygon coverage",
+                                })
+                        except Exception:
+                            continue
+    except Exception:
+        pass
+    return issues
+
+
+def _detect_overlaps(
+    gdf: gpd.GeoDataFrame,
+    tolerance: float = 0.0,
+) -> List[Dict[str, Any]]:
+    """
+    Detect overlapping polygon pairs. Reports one issue per pair (feature_id, other_feature_id).
+    """
+    issues: List[Dict[str, Any]] = []
+    indices = list(gdf.index)
+    geoms = gdf.geometry
+    for i in range(len(indices)):
+        idx_i = indices[i]
+        geom_i = geoms.loc[idx_i] if hasattr(geoms, "loc") else geoms.iloc[i]
+        if geom_i is None or geom_i.is_empty or not hasattr(geom_i, "exterior"):
+            continue
+        if not getattr(geom_i, "is_valid", True):
+            continue
+        for j in range(i + 1, len(indices)):
+            idx_j = indices[j]
+            geom_j = geoms.loc[idx_j] if hasattr(geoms, "loc") else geoms.iloc[j]
+            if geom_j is None or geom_j.is_empty or not hasattr(geom_j, "exterior"):
+                continue
+            if not getattr(geom_j, "is_valid", True):
+                continue
+            try:
+                inter = geom_i.intersection(geom_j)
+                if inter.is_empty:
+                    continue
+                area = getattr(inter, "area", None)
+                if area is None:
+                    area = 0.0
+                if area <= tolerance:
+                    continue
+                loc = _location(inter)
+                fid_i = _get_feature_id(gdf, idx_i)
+                fid_j = _get_feature_id(gdf, idx_j)
+                issues.append({
+                    "feature_id": fid_i,
+                    "other_feature_id": fid_j,
+                    "type": TopologyIssueType.OVERLAP,
+                    "severity": Severity.WARNING,
+                    "location": loc,
+                    "description": f"Overlap with feature {fid_j}",
+                })
+            except Exception:
+                continue
+    return issues
+
+
+def _line_endpoints(geom: BaseGeometry) -> List[Point]:
+    """Return list of (start, end) or flattened points for LineString/MultiLineString."""
+    points: List[Point] = []
+    if geom is None or geom.is_empty:
+        return points
+    if isinstance(geom, LineString):
+        if len(geom.coords) >= 2:
+            points.append(Point(geom.coords[0]))
+            points.append(Point(geom.coords[-1]))
+        return points
+    if hasattr(geom, "geoms"):
+        for g in geom.geoms:
+            points.extend(_line_endpoints(g))
+        return points
+    return points
+
+
+def _point_touches_line(pt: Point, line_geom: BaseGeometry, tolerance: float) -> bool:
+    """True if pt is within tolerance of line (boundary or interior)."""
+    if line_geom is None or line_geom.is_empty:
+        return False
+    try:
+        dist = line_geom.distance(pt)
+        return dist <= tolerance
+    except Exception:
+        return False
+
+
+def _detect_dangles(gdf: gpd.GeoDataFrame, tolerance: float = 1e-9) -> List[Dict[str, Any]]:
+    """
+    Detect dangles: line endpoints that do not touch any other line (disconnected).
+    Intended for LineString/MultiLineString layers.
+    """
+    issues: List[Dict[str, Any]] = []
+    indices = list(gdf.index)
+    geoms = gdf.geometry
+    for i in range(len(indices)):
+        idx = indices[i]
+        geom = geoms.loc[idx] if hasattr(geoms, "loc") else geoms.iloc[i]
+        if geom is None or geom.is_empty:
+            continue
+        endpoints = _line_endpoints(geom)
+        for pt in endpoints:
+            if pt is None or pt.is_empty:
+                continue
+            touches_other = False
+            for j in range(len(indices)):
+                if j == i:
+                    continue
+                other = geoms.loc[indices[j]] if hasattr(geoms, "loc") else geoms.iloc[j]
+                if _point_touches_line(pt, other, tolerance):
+                    touches_other = True
+                    break
+            if not touches_other:
+                loc = _location(pt)
+                fid = _get_feature_id(gdf, idx)
+                issues.append({
+                    "feature_id": fid,
+                    "other_feature_id": None,
+                    "type": TopologyIssueType.DANGLE,
+                    "severity": Severity.WARNING,
+                    "location": loc,
+                    "description": "Disconnected line endpoint (dangle)",
+                })
+    return issues
+
+
+def validate_topology(
+    gdf: gpd.GeoDataFrame,
+    *,
+    check_gaps: bool = True,
+    check_overlaps: bool = True,
+    check_connectivity: bool = True,
+    tolerance: float = 0.0,
+) -> List[Dict[str, Any]]:
+    """
+    Run topology validation on a GeoDataFrame (issue #80).
+
+    Args:
+        gdf: GeoDataFrame with a geometry column.
+        check_gaps: Report gaps (holes in polygon coverage).
+        check_overlaps: Report overlapping polygon pairs.
+        check_connectivity: Report dangles (disconnected line endpoints).
+        tolerance: Minimum area for overlap; distance for endpoint touch (default 0).
+
+    Returns:
+        List of violation dicts with keys: feature_id, other_feature_id (optional),
+        type (topology_gap, topology_overlap, topology_dangle), severity, location, description.
+    """
+    if gdf is None or gdf.empty or gdf.geometry is None:
+        return []
+    issues: List[Dict[str, Any]] = []
+    # Polygon-based checks
+    if check_gaps or check_overlaps:
+        if check_gaps:
+            issues.extend(_detect_gaps(gdf))
+        if check_overlaps:
+            issues.extend(_detect_overlaps(gdf, tolerance=tolerance))
+    # Line-based check
+    if check_connectivity:
+        issues.extend(_detect_dangles(gdf, tolerance=tolerance if tolerance > 0 else 1e-9))
+    return issues

--- a/backend/tests/test_topology.py
+++ b/backend/tests/test_topology.py
@@ -1,0 +1,126 @@
+"""Tests for core.topology (issue #80)."""
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString, Point, Polygon
+
+from core.topology import (
+    TopologyIssueType,
+    Severity,
+    validate_topology,
+)
+
+
+def test_validate_topology_empty_gdf():
+    """Empty GeoDataFrame returns no issues."""
+    gdf = gpd.GeoDataFrame(geometry=[])
+    assert validate_topology(gdf) == []
+
+
+def test_validate_topology_gap_hole_in_union():
+    """A polygon with an interior ring (hole) produces a gap issue."""
+    # One polygon with a hole: outer square, inner square as hole
+    outer = [(0, 0), (3, 0), (3, 3), (0, 3), (0, 0)]
+    hole = [(1, 1), (2, 1), (2, 2), (1, 2), (1, 1)]
+    poly_with_hole = Polygon(outer, [hole])
+    gdf = gpd.GeoDataFrame(geometry=[poly_with_hole], index=[5])
+    issues = validate_topology(gdf, check_overlaps=False, check_connectivity=False)
+    gaps = [i for i in issues if i["type"] == TopologyIssueType.GAP]
+    assert len(gaps) >= 1
+    assert gaps[0]["feature_id"] is None
+    assert gaps[0]["location"] is not None
+    assert "Gap" in (gaps[0]["description"] or "")
+
+
+def test_validate_topology_overlap_two_polygons():
+    """Two overlapping polygons produce one overlap issue."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)]),
+            Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)]),
+        ],
+        index=[10, 20],
+    )
+    issues = validate_topology(gdf, check_gaps=False, check_connectivity=False)
+    assert len(issues) >= 1
+    overlap = next((i for i in issues if i["type"] == TopologyIssueType.OVERLAP), None)
+    assert overlap is not None
+    assert overlap["feature_id"] == 10
+    assert overlap["other_feature_id"] == 20
+    assert overlap["severity"] == Severity.WARNING
+    assert overlap["location"] is not None
+    assert "Overlap" in (overlap["description"] or "")
+
+
+def test_validate_topology_no_overlap_when_touching():
+    """Two polygons that only touch (no area overlap) produce no overlap issue."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]),
+            Polygon([(1, 0), (2, 0), (2, 1), (1, 1), (1, 0)]),
+        ],
+    )
+    issues = validate_topology(gdf, check_gaps=False, check_connectivity=False)
+    overlaps = [i for i in issues if i["type"] == TopologyIssueType.OVERLAP]
+    assert len(overlaps) == 0
+
+
+def test_validate_topology_dangle_line():
+    """A line whose endpoint does not touch another line produces a dangle issue."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            LineString([(0, 0), (1, 0)]),
+            LineString([(2, 0), (3, 0)]),  # disconnected
+        ],
+        index=[1, 2],
+    )
+    issues = validate_topology(gdf, check_gaps=False, check_overlaps=False)
+    dangles = [i for i in issues if i["type"] == TopologyIssueType.DANGLE]
+    assert len(dangles) >= 1
+    assert any(d["feature_id"] in (1, 2) for d in dangles)
+    assert any(d["location"] is not None for d in dangles)
+
+
+def test_validate_topology_connected_lines_shared_endpoint_not_dangle():
+    """Two lines that meet at (1,0) produce dangles only at the two open ends (0,0) and (1,1)."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            LineString([(0, 0), (1, 0)]),
+            LineString([(1, 0), (1, 1)]),
+        ],
+    )
+    issues = validate_topology(gdf, check_gaps=False, check_overlaps=False)
+    dangles = [i for i in issues if i["type"] == TopologyIssueType.DANGLE]
+    # Open ends at (0,0) and (1,1) are dangles; shared vertex (1,0) is not
+    assert len(dangles) == 2
+
+
+def test_validate_topology_respects_check_flags():
+    """Disabling a check skips that detection."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)]),
+            Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)]),
+        ],
+    )
+    issues_all = validate_topology(gdf, check_overlaps=True, check_gaps=False, check_connectivity=False)
+    issues_no_overlap = validate_topology(gdf, check_overlaps=False, check_gaps=False, check_connectivity=False)
+    assert len(issues_all) >= 1
+    assert len(issues_no_overlap) == 0
+
+
+def test_validate_topology_issue_structure():
+    """Each violation has feature_id, type, severity, location, description."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)]),
+            Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)]),
+        ],
+    )
+    issues = validate_topology(gdf, check_gaps=False, check_connectivity=False)
+    for issue in issues:
+        assert "feature_id" in issue
+        assert "type" in issue
+        assert "severity" in issue
+        assert "location" in issue
+        assert "description" in issue
+        assert issue["type"].startswith("topology_")


### PR DESCRIPTION
## Summary
Implements **issue #80** ([#8] Implement topology validation logic (gaps, overlaps, connectivity)): core topology validation using GeoPandas/Shapely that detects gaps, overlaps, and disconnected line endpoints (dangles), and returns structured violation dicts for use by the Topology Agent.

## Changes

### New: `backend/core/topology.py`
- **`validate_topology(gdf, check_gaps=True, check_overlaps=True, check_connectivity=True, tolerance=0.0)`**
  - **Gaps:** Uses `unary_union` of polygon geometries; each interior ring (hole) in the union is reported as a gap. Intended for polygon layers (e.g. unclosed coverage). `feature_id` is `None` for gaps.
  - **Overlaps:** Pairwise polygon intersection; reports when intersection area &gt; `tolerance`. Each issue includes `feature_id`, `other_feature_id`, `location` (centroid of intersection), and description.
  - **Connectivity (dangles):** For LineString/MultiLineString, finds endpoints that do not touch any other line within `tolerance`; reports `topology_dangle` with `feature_id` and `location` (endpoint).
- **Output:** List of dicts with `feature_id`, `other_feature_id` (optional), `type` (`topology_gap`, `topology_overlap`, `topology_dangle`), `severity`, `location`, `description` — suitable for conversion to `GeometryIssue` in the Topology Agent (#81).
- **Module docstring:** Documents assumptions (planar CRS, polygon vs line use) and limitations (O(n²) overlap check for large datasets; ArcGIS-specific rules not implemented).
- **Constants:** `TopologyIssueType`, `Severity`; helpers `_get_feature_id`, `_location` aligned with `core.validation`.

### New: `backend/tests/test_topology.py`
- Empty GeoDataFrame → no issues.
- One polygon with interior ring (hole) → gap issue.
- Two overlapping polygons → overlap issue with correct feature_ids and location.
- Two touching (non-overlapping) polygons → no overlap.
- Disconnected lines → dangle issue(s).
- Two lines meeting at one endpoint → two dangles at the two open ends only.
- Check flags → disabling a check skips that detection.
- Issue structure → every violation has required keys and `type` prefix `topology_`.

## Acceptance criteria (issue #80)
- [x] Add a module that accepts a GeoDataFrame and optional topology rules (check flags + tolerance).
- [x] Detect gaps (holes in polygon coverage via unary_union).
- [x] Detect overlaps (pairwise polygon intersection area).
- [x] Detect connectivity issues (dangles: line endpoints not touching another line).
- [x] Return structured violations: feature_id(s), type, severity, location.
- [x] Document assumptions and limitations.

## Related issues
- Closes #80
- Parent: #8 (Topology validation)
- Enables #81 (Topology Agent node) to call this module and append topology issues to state.