### PR TITLE
feat(#81): Topology Agent node and unit tests

### DIFF
--- a/backend/agents/topology_agent.py
+++ b/backend/agents/topology_agent.py
@@ -1,11 +1,76 @@
-"""Topology validation agent: gaps, overlaps, connectivity. Stub for #61."""
+"""
+Topology validation agent: gaps, overlaps, connectivity (issue #81).
+
+Loads the dataset from state, runs core.topology.validate_topology, and appends
+topology issues to state["issues"] as GeometryIssue (type=topology_gap, topology_overlap,
+topology_dangle). Same pattern as attribute_agent (#73).
+"""
+from typing import Any, Dict, List, Optional
+
+import geopandas as gpd
+
+from api.models import GeometryIssue
 from agents.state import ValidationState
+from core.topology import validate_topology
 
 
-def run(state: ValidationState) -> dict:
+def _violation_to_geometry_issue(v: Dict[str, Any]) -> GeometryIssue:
+    """Map a topology violation dict to GeometryIssue for state["issues"]."""
+    return GeometryIssue(
+        feature_id=v.get("feature_id"),
+        type=v.get("type", "topology_other"),
+        severity=v.get("severity") or "warning",
+        location=v.get("location"),
+        description=v.get("description") or None,
+    )
+
+
+def run(
+    state: ValidationState,
+    *,
+    check_gaps: bool = True,
+    check_overlaps: bool = True,
+    check_connectivity: bool = True,
+    tolerance: float = 0.0,
+) -> dict:
     """
-    Run topology validation on the dataset in state.
-    Returns partial state update (e.g. {"issues": [...]}).
-    Stub: no-op until topology validation is implemented.
+    Run topology validation on the dataset in state (issue #81).
+
+    - Loads the dataset from state["dataset_path"] with GeoPandas.
+    - Calls core.topology.validate_topology to get violations (gaps, overlaps, dangles).
+    - Converts violations to GeometryIssue and appends to state["issues"].
+
+    Deterministic and side-effect free apart from the returned state update.
+
+    Args:
+        state: Current validation state (dataset_path, issues, ...).
+        check_gaps: Enable gap detection (holes in polygon coverage).
+        check_overlaps: Enable overlap detection.
+        check_connectivity: Enable dangle detection (disconnected line endpoints).
+        tolerance: Passed to validate_topology (overlap area / endpoint distance).
+
+    Returns:
+        Partial state update: {"issues": existing_issues + new_topology_issues}.
     """
-    return {}
+    existing = list(state.get("issues") or [])
+    path = state.get("dataset_path")
+    if not path:
+        return {"issues": existing}
+
+    try:
+        gdf = gpd.read_file(path)
+    except Exception:
+        return {"issues": existing}
+
+    if gdf is None or gdf.empty:
+        return {"issues": existing}
+
+    raw: List[Dict[str, Any]] = validate_topology(
+        gdf,
+        check_gaps=check_gaps,
+        check_overlaps=check_overlaps,
+        check_connectivity=check_connectivity,
+        tolerance=tolerance,
+    )
+    new_issues = [_violation_to_geometry_issue(v) for v in raw]
+    return {"issues": existing + new_issues}

--- a/backend/tests/test_topology_agent.py
+++ b/backend/tests/test_topology_agent.py
@@ -1,0 +1,120 @@
+"""Tests for agents.topology_agent (issue #81)."""
+from pathlib import Path
+from unittest.mock import patch
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Polygon
+
+from agents.topology_agent import run as topology_agent_run
+
+
+def _minimal_geojson_path(tmp_path: Path) -> Path:
+    """Create a minimal GeoJSON with two polygons."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]),
+            Polygon([(1, 0), (2, 0), (2, 1), (1, 1), (1, 0)]),
+        ],
+    )
+    path = tmp_path / "sample.geojson"
+    gdf.to_file(path, driver="GeoJSON")
+    return path
+
+
+def test_run_appends_topology_issues_to_state(tmp_path):
+    """Topology agent calls validate_topology and appends GeometryIssue to state."""
+    path = _minimal_geojson_path(tmp_path)
+    state = {"dataset_id": "test", "dataset_path": str(path), "issues": []}
+
+    mock_violations = [
+        {
+            "feature_id": 10,
+            "other_feature_id": 20,
+            "type": "topology_overlap",
+            "severity": "warning",
+            "location": [0.5, 0.5],
+            "description": "Overlap with feature 20",
+        }
+    ]
+
+    with patch("agents.topology_agent.validate_topology", return_value=mock_violations):
+        result = topology_agent_run(state)
+
+    assert "issues" in result
+    issues = result["issues"]
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue.feature_id == 10
+    assert issue.type == "topology_overlap"
+    assert issue.severity == "warning"
+    assert issue.location == [0.5, 0.5]
+    assert "Overlap" in (issue.description or "")
+
+
+def test_run_with_no_dataset_path_returns_existing_issues():
+    """When dataset_path is missing, return state with no new issues."""
+    state = {"dataset_id": "test", "dataset_path": None, "issues": []}
+    result = topology_agent_run(state)
+    assert result["issues"] == []
+
+
+def test_run_with_invalid_path_returns_existing_issues():
+    """When path is invalid or unreadable, return existing issues only."""
+    state = {"dataset_id": "test", "dataset_path": "/nonexistent/file.geojson", "issues": []}
+    result = topology_agent_run(state)
+    assert result["issues"] == []
+
+
+def test_run_preserves_existing_issues(tmp_path):
+    """New topology issues are appended to existing geometry/attribute issues."""
+    path = _minimal_geojson_path(tmp_path)
+    from api.models import GeometryIssue
+
+    existing = [
+        GeometryIssue(
+            feature_id=99, type="empty_geometry", severity="critical",
+            location=None, description="Empty",
+        ),
+    ]
+    state = {"dataset_path": str(path), "issues": existing}
+
+    mock_violations = [
+        {
+            "feature_id": 0,
+            "other_feature_id": None,
+            "type": "topology_gap",
+            "severity": "warning",
+            "location": [0.5, 0.5],
+            "description": "Gap in polygon coverage",
+        },
+    ]
+
+    with patch("agents.topology_agent.validate_topology", return_value=mock_violations):
+        result = topology_agent_run(state)
+
+    assert len(result["issues"]) == 2
+    assert result["issues"][0].feature_id == 99
+    assert result["issues"][0].type == "empty_geometry"
+    assert result["issues"][1].feature_id == 0
+    assert result["issues"][1].type == "topology_gap"
+
+
+def test_run_with_real_overlap(tmp_path):
+    """With real overlapping polygons, topology agent returns overlap issues (no mock)."""
+    gdf = gpd.GeoDataFrame(
+        geometry=[
+            Polygon([(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)]),
+            Polygon([(1, 1), (3, 1), (3, 3), (1, 3), (1, 1)]),
+        ],
+    )
+    path = tmp_path / "overlap.geojson"
+    gdf.to_file(path, driver="GeoJSON")
+    state = {"dataset_path": str(path), "issues": []}
+
+    result = topology_agent_run(state)
+
+    assert "issues" in result
+    overlaps = [i for i in result["issues"] if i.type == "topology_overlap"]
+    assert len(overlaps) >= 1
+    assert overlaps[0].location is not None


### PR DESCRIPTION
## Summary
Implements the **Topology Agent** as a LangGraph node (issue **#81**, sub-issue of **#8**). The node loads the dataset from state, runs topology validation via `core.topology`, and appends topology issues to shared state, following the same pattern as the Attribute Agent (#73).

## Related issues
- Closes #81
- Parent: #8 (Topology validation)
- Builds on: #80 (topology validation logic), merged in PR #83

## Changes
- **`backend/agents/topology_agent.py`**
  - `run(state, *, check_gaps=True, check_overlaps=True, check_connectivity=True, tolerance=0.0)`:
    - Reads `state["dataset_path"]` and loads with GeoPandas.
    - Calls `core.topology.validate_topology(...)` for gaps, overlaps, and connectivity (dangles).
    - Maps each violation to `GeometryIssue` (feature_id, type, severity, location, description).
    - Returns `{"issues": existing + new_topology_issues}`.
  - Deterministic and side-effect free apart from state updates.
- **`backend/tests/test_topology_agent.py`** (new)
  - Tests: appends topology issues (mocked), no path / invalid path, preserves existing issues, real overlap fixture.

## Acceptance criteria (from #81)
- [x] Implement `agents/topology_agent.run(state)` with dataset load, topology validation call, GeometryIssue conversion, and `{"issues": existing + new}`.
- [x] Node deterministic and side-effect free.
- [x] Basic unit tests (mocked + small fixture).