### PR TITLE
feat(#86): Define suggestion schema and apply-corrections compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,14 +645,12 @@ Response: 200 OK
 POST /corrections/apply
 Content-Type: application/json
 
-Body:
+Body (ApplyCorrectionsRequest, issue #86):
 {
-  "task_id": "uuid-string",
+  "dataset_id": "uuid-string",
   "corrections": [
-    {
-      "issue_id": "issue-1",
-      "action": "approve"
-    }
+    { "issue_index": 0, "action": "approve" },
+    { "issue_index": 1, "action": "reject" }
   ]
 }
 
@@ -663,6 +661,8 @@ Response: 200 OK
   "download_url": "/download/cleaned_dataset.zip"
 }
 ```
+
+**Suggestion schema (issue #86):** Validation results may include a `corrections` list. Each item is a **CorrectionSuggestion** (`api/models.py`): `method` (e.g. `buffer(0)`, `rename field`), `confidence` (0–1), `explanation` (natural-language), and `issue_index` (index into the `issues` list). The Recommendation Agent populates `state["corrections"]` in this shape. The apply-corrections API accepts **CorrectionAction** entries (`issue_index`, `action`: `approve` | `reject`) so the client can approve or reject each suggestion by issue index.
 
 [Full API documentation](docs/api/README.md)
 

--- a/backend/agents/state.py
+++ b/backend/agents/state.py
@@ -27,7 +27,7 @@ class ValidationState(TypedDict, total=False):
     """All validation issues found (geometry, attribute, topology)."""
 
     corrections: List[dict]
-    """Suggested or applied corrections. Structure TBD by recommendation agent."""
+    """Suggested corrections from Recommendation Agent. Each dict matches api.models.CorrectionSuggestion (method, confidence, explanation, issue_index)."""
 
     user_approvals: List[bool]
     """User decisions per correction (e.g. approve/reject)."""

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,5 +1,5 @@
 """Pydantic schemas for API request/response."""
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -36,11 +36,46 @@ class UploadResponse(BaseModel):
     bounds: Optional[List[float]] = Field(None, description="[minX, minY, maxX, maxY]")
 
 
+class CorrectionSuggestion(BaseModel):
+    """
+    A suggested fix for a validation issue (issue #86, #9).
+
+    Used by the Recommendation Agent and apply-corrections API. issue_index links
+    this suggestion to state["issues"][issue_index] (or the validation result issues list).
+    """
+
+    method: str = Field(..., description="Suggested fix e.g. buffer(0), rename field, snap to grid")
+    confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence score 0–1")
+    explanation: str = Field(..., description="Natural-language explanation for the suggestion")
+    issue_index: int = Field(..., ge=0, description="Index into the issues list this suggestion applies to")
+
+
+class CorrectionAction(BaseModel):
+    """User decision for one correction (apply-corrections API request body)."""
+
+    issue_index: int = Field(..., ge=0, description="Index into the issues list")
+    action: Literal["approve", "reject"] = Field(..., description="Whether to apply or skip this correction")
+
+
+class ApplyCorrectionsRequest(BaseModel):
+    """Request body for POST /corrections/apply (issue #86)."""
+
+    dataset_id: str = Field(..., description="Dataset identifier")
+    corrections: List[CorrectionAction] = Field(
+        default_factory=list,
+        description="List of approve/reject decisions per issue index",
+    )
+
+
 class ValidationResult(BaseModel):
     """Result of geometry validation for a dataset."""
 
     dataset_id: str = Field(..., description="Dataset identifier that was validated")
     issues: List[GeometryIssue] = Field(default_factory=list, description="List of geometry issues found")
+    corrections: Optional[List[CorrectionSuggestion]] = Field(
+        None,
+        description="Suggested fixes from Recommendation Agent (one per issue or subset); indices match issues list",
+    )
 
 
 class ValidationJobStatus(BaseModel):

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -140,7 +140,8 @@ async def validate_dataset(body: ValidateRequest):
     initial_state = empty_state(body.dataset_id, str(path))
     final_state = validation_graph.invoke(initial_state)
     issues = final_state.get("issues") or []
-    return ValidationResult(dataset_id=body.dataset_id, issues=issues)
+    corrections = final_state.get("corrections") or []
+    return ValidationResult(dataset_id=body.dataset_id, issues=issues, corrections=corrections if corrections else None)
 
 
 @router.get(
@@ -168,7 +169,8 @@ async def get_validation_results(dataset_id: str):
     initial_state = empty_state(dataset_id, str(path))
     final_state = validation_graph.invoke(initial_state)
     issues = final_state.get("issues") or []
-    return ValidationResult(dataset_id=dataset_id, issues=issues)
+    corrections = final_state.get("corrections") or []
+    return ValidationResult(dataset_id=dataset_id, issues=issues, corrections=corrections if corrections else None)
 
 
 @router.post(
@@ -214,7 +216,12 @@ async def validate_dataset_async(body: ValidateRequest, background_tasks: Backgr
             state = empty_state(dataset_id, dataset_path)
             final_state = validation_graph.invoke(state)
             issues = final_state.get("issues") or []
-            result = ValidationResult(dataset_id=dataset_id, issues=issues)
+            corrections = final_state.get("corrections") or []
+            result = ValidationResult(
+                dataset_id=dataset_id,
+                issues=issues,
+                corrections=corrections if corrections else None,
+            )
             job["result"] = result
             job["status"] = "completed"
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
Defines the **suggestion/correction data model** and aligns it with the apply-corrections API contract (issue **#86**, sub-issue of **#9**). Enables the Recommendation Agent (#87) to output structured suggestions and prepares request/response shapes for a future apply-corrections endpoint.

## Related issues
- Closes #86
- Parent: #9 (Recommendation generation)
- Unblocks: #87 (Implement Recommendation Agent), future apply-corrections implementation

## Changes

### API models (`backend/api/models.py`)
- **CorrectionSuggestion**: `method` (str), `confidence` (float 0–1), `explanation` (str), `issue_index` (int ≥ 0). Links each suggestion to `state["issues"][issue_index]`.
- **CorrectionAction**: `issue_index` (int), `action` (`approve` | `reject`) for the apply-corrections request body.
- **ApplyCorrectionsRequest**: `dataset_id`, `corrections: List[CorrectionAction]` for a future `POST /corrections/apply`.
- **ValidationResult**: Optional `corrections: Optional[List[CorrectionSuggestion]] = None` so validation responses can include suggestions when the Recommendation Agent populates them.

### Routes (`backend/api/routes.py`)
- All validation endpoints (POST `/validate`, GET `/validate/{dataset_id}`, async job completion) pass through `final_state.get("corrections")` into `ValidationResult`, so corrections from the graph are returned in the API response.

### State (`backend/agents/state.py`)
- Docstring for `corrections` updated to state that each dict matches `CorrectionSuggestion` (method, confidence, explanation, issue_index).

### README
- Apply Corrections example updated to use `dataset_id` and `corrections: [{ issue_index, action }]`.
- New **Suggestion schema (issue #86)** paragraph: documents `CorrectionSuggestion`, `issue_index`, and `ApplyCorrectionsRequest` / `CorrectionAction` compatibility.

## Acceptance criteria (from #86)
- [x] Suggestion/correction schema defined (api.models: CorrectionSuggestion, CorrectionAction, ApplyCorrectionsRequest); state docstring updated.
- [x] Schema compatible with apply-corrections API (request/response shapes defined and documented).
- [x] Document in README (Apply Corrections body + Suggestion schema subsection).