### PR TITLE
feat(#87): Implement Recommendation Agent (GPT-4 + rules) and unit tests

### DIFF
--- a/backend/agents/recommendation_agent.py
+++ b/backend/agents/recommendation_agent.py
@@ -1,11 +1,150 @@
-"""Recommendation agent: generate correction suggestions from issues. Stub for #61."""
+"""
+Recommendation agent: generate correction suggestions from issues (issue #87, #9).
+
+Consumes state["issues"] (geometry, attribute, topology), produces one CorrectionSuggestion
+per issue (method, confidence, explanation, issue_index). Uses GPT-4 when an LLM is
+provided; otherwise uses rule-based fallbacks. Output is compatible with apply-corrections API.
+"""
+from typing import Any, Dict, List, Optional
+
+from api.models import CorrectionSuggestion
 from agents.state import ValidationState
+from services.llm_service import (
+    SupportsInvoke,
+    get_recommendation_suggestions_from_llm,
+)
 
 
-def run(state: ValidationState) -> dict:
+def _issue_to_dict(issue: Any) -> Dict[str, Any]:
+    """Convert an issue (GeometryIssue or dict) to a minimal dict for LLM or rules."""
+    if isinstance(issue, dict):
+        return {
+            "type": issue.get("type", ""),
+            "severity": issue.get("severity", ""),
+            "description": issue.get("description") or "",
+        }
+    return {
+        "type": getattr(issue, "type", ""),
+        "severity": getattr(issue, "severity", ""),
+        "description": getattr(issue, "description") or "",
+    }
+
+
+def _rule_based_suggestion(issue: Any) -> Dict[str, Any]:
     """
-    Generate correction recommendations from current issues.
-    Returns partial state update (e.g. {"corrections": [...]}).
-    Stub: returns empty corrections until recommendation logic is implemented.
+    Return a default method, confidence, and explanation for known issue types.
+    Used when no LLM is provided or as fallback.
     """
-    return {"corrections": []}
+    d = _issue_to_dict(issue)
+    itype = (d.get("type") or "").lower()
+    desc = (d.get("description") or "")[:300]
+
+    if "self_intersection" in itype or "invalid_geometry" in itype:
+        return {
+            "method": "buffer(0)",
+            "confidence": 0.9,
+            "explanation": "Apply zero-distance buffer to resolve self-intersection or invalid polygon.",
+        }
+    if "empty_geometry" in itype or "null" in itype:
+        return {
+            "method": "delete or replace geometry",
+            "confidence": 0.8,
+            "explanation": "Remove or replace the empty/null geometry.",
+        }
+    if "topology_overlap" in itype:
+        return {
+            "method": "merge or clip overlapping features",
+            "confidence": 0.7,
+            "explanation": "Adjust boundaries or merge overlapping polygons to remove overlap.",
+        }
+    if "topology_gap" in itype:
+        return {
+            "method": "add missing polygon or adjust boundaries",
+            "confidence": 0.6,
+            "explanation": "Fill the gap with a new polygon or extend adjacent boundaries.",
+        }
+    if "topology_dangle" in itype:
+        return {
+            "method": "snap endpoint to nearest line or extend",
+            "confidence": 0.65,
+            "explanation": "Connect the dangle endpoint to the network or extend the line.",
+        }
+    if itype.startswith("attribute_"):
+        return {
+            "method": "apply suggested value",
+            "confidence": 0.85,
+            "explanation": desc or "Correct the attribute value per validation suggestion.",
+        }
+    # Generic
+    return {
+        "method": "manual review",
+        "confidence": 0.5,
+        "explanation": f"Issue type: {itype or 'unknown'}. Review and fix manually.",
+    }
+
+
+def run(
+    state: ValidationState,
+    *,
+    llm: Optional[SupportsInvoke] = None,
+) -> dict:
+    """
+    Generate correction suggestions for all issues in state (issue #87).
+
+    - Reads state["issues"] (geometry, attribute, topology).
+    - For each issue, produces a suggestion (method, confidence, explanation) using
+      GPT-4 when llm is provided, otherwise rule-based fallbacks.
+    - Returns {"corrections": [...]} where each item is a CorrectionSuggestion
+      (method, confidence, explanation, issue_index) compatible with the apply-corrections API.
+
+    Args:
+        state: Current validation state (issues, ...).
+        llm: Optional LangChain-compatible LLM for context-aware suggestions; if None, uses rules only.
+
+    Returns:
+        Partial state update: {"corrections": list of CorrectionSuggestion dicts}.
+    """
+    issues = list(state.get("issues") or [])
+    if not issues:
+        return {"corrections": []}
+
+    issue_dicts = [_issue_to_dict(iss) for iss in issues]
+
+    if llm is not None:
+        try:
+            raw_suggestions = get_recommendation_suggestions_from_llm(issue_dicts, llm=llm)
+        except Exception:
+            raw_suggestions = []
+        if len(raw_suggestions) >= len(issues):
+            suggestions = [
+                CorrectionSuggestion(
+                    method=raw_suggestions[i]["method"],
+                    confidence=raw_suggestions[i]["confidence"],
+                    explanation=raw_suggestions[i]["explanation"],
+                    issue_index=i,
+                )
+                for i in range(len(issues))
+            ]
+        else:
+            # Fallback to rules if LLM returned too few
+            suggestions = []
+            for i, iss in enumerate(issues):
+                rule = _rule_based_suggestion(iss)
+                suggestions.append(
+                    CorrectionSuggestion(
+                        method=rule["method"],
+                        confidence=rule["confidence"],
+                        explanation=rule["explanation"],
+                        issue_index=i,
+                    )
+                )
+    else:
+        suggestions = [
+            CorrectionSuggestion(
+                issue_index=i,
+                **_rule_based_suggestion(iss),
+            )
+            for i, iss in enumerate(issues)
+        ]
+
+    return {"corrections": [s.model_dump() for s in suggestions]}

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -224,11 +224,123 @@ def validate_attributes_with_llm(
     return parse_llm_attribute_issues(response)
 
 
+# --- Recommendation suggestions (issue #87) ---
+
+
+def build_recommendation_prompt(issues: List[Dict[str, Any]]) -> str:
+    """
+    Build a prompt for GPT-4 to suggest a fix (method, confidence, explanation) per issue.
+
+    Args:
+        issues: List of dicts with at least "type", "severity", "description" (and optionally
+                "feature_id"). Typically from state["issues"] converted to dict.
+
+    Returns:
+        Prompt string. Model is asked to return JSON: {"suggestions": [{ "method", "confidence", "explanation" }, ...]}
+        in the same order as the input issues.
+    """
+    if not issues:
+        return ""
+    # Compact representation for the prompt
+    compact = []
+    for i, iss in enumerate(issues):
+        if isinstance(iss, dict):
+            row = iss
+        else:
+            row = {"type": getattr(iss, "type", ""), "severity": getattr(iss, "severity", ""), "description": getattr(iss, "description") or ""}
+        compact.append({"index": i, "type": row.get("type", ""), "severity": row.get("severity", ""), "description": (row.get("description") or "")[:200]})
+    instructions = (
+        "You are a geospatial data quality assistant. For each validation issue below, "
+        "suggest a correction: a short method name (e.g. buffer(0), rename field, snap to grid), "
+        "a confidence score from 0 to 1, and a brief natural-language explanation.\n\n"
+        "Return ONLY valid JSON with this structure (one suggestion per issue, same order as input):\n"
+        "{\n  \"suggestions\": [\n"
+        "    { \"method\": \"...\", \"confidence\": 0.9, \"explanation\": \"...\" },\n"
+        "    ...\n  ]\n}\n\n"
+        "Keep method names short and actionable. Confidence should reflect how likely the fix is to resolve the issue.\n"
+    )
+    return instructions + "\nISSUES=\n" + json.dumps(compact, default=str)
+
+
+def parse_recommendation_suggestions(raw: Any) -> List[Dict[str, Any]]:
+    """
+    Parse LLM response into a list of suggestion dicts (method, confidence, explanation).
+
+    Returns one entry per suggestion; if the response has fewer than expected, missing entries
+    are filled with a default. On parse error, returns empty list.
+    """
+    if raw is None:
+        return []
+    content = raw if isinstance(raw, str) else getattr(raw, "content", None)
+    if not isinstance(content, str):
+        return []
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        return []
+    suggestions = data.get("suggestions") if isinstance(data, dict) else None
+    if not isinstance(suggestions, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    default = {"method": "manual review", "confidence": 0.5, "explanation": "No suggestion generated."}
+    for item in suggestions:
+        if not isinstance(item, dict):
+            out.append(default.copy())
+            continue
+        method = item.get("method") or default["method"]
+        try:
+            conf = float(item.get("confidence", 0.5))
+            conf = max(0.0, min(1.0, conf))
+        except (TypeError, ValueError):
+            conf = 0.5
+        explanation = item.get("explanation") or default["explanation"]
+        if not isinstance(explanation, str):
+            explanation = str(explanation)[:500]
+        out.append({"method": str(method)[:200], "confidence": conf, "explanation": explanation})
+    return out
+
+
+def get_recommendation_suggestions_from_llm(
+    issues: List[Dict[str, Any]],
+    *,
+    llm: Optional[SupportsInvoke] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Call GPT-4 to get correction suggestions (method, confidence, explanation) for each issue.
+
+    Args:
+        issues: List of issue dicts (type, severity, description, ...).
+        llm: Optional LangChain-compatible LLM; if None, uses default ChatOpenAI.
+
+    Returns:
+        List of dicts with keys method, confidence, explanation (same order as issues).
+        Empty list on error or if no issues.
+    """
+    if not issues:
+        return []
+    prompt = build_recommendation_prompt(issues)
+    if not prompt:
+        return []
+    client = llm or _default_llm()
+    try:
+        response = client.invoke(prompt)
+    except Exception:
+        return []
+    parsed = parse_recommendation_suggestions(response)
+    # Pad to match issue count if LLM returned fewer
+    while len(parsed) < len(issues):
+        parsed.append({"method": "manual review", "confidence": 0.5, "explanation": "No suggestion generated."})
+    return parsed[: len(issues)]
+
+
 __all__ = [
     "AttributeIssue",
     "AttributeValidationConfig",
     "build_attribute_validation_prompt",
     "parse_llm_attribute_issues",
     "validate_attributes_with_llm",
+    "build_recommendation_prompt",
+    "parse_recommendation_suggestions",
+    "get_recommendation_suggestions_from_llm",
 ]
 

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -114,3 +114,33 @@ def test_validate_attributes_with_llm_empty_input_returns_empty_and_skips_llm():
     assert issues == []
     assert llm.last_prompt is None
 
+
+# --- Recommendation suggestions (issue #87) ---
+
+
+def test_build_recommendation_prompt_contains_issues():
+    """Recommendation prompt includes issue type, severity, description."""
+    from services.llm_service import build_recommendation_prompt
+
+    issues = [{"type": "self_intersection", "severity": "critical", "description": "Ring self-intersects"}]
+    prompt = build_recommendation_prompt(issues)
+    assert "self_intersection" in prompt
+    assert "critical" in prompt
+    assert "suggestions" in prompt
+    assert "method" in prompt and "confidence" in prompt and "explanation" in prompt
+
+
+def test_parse_recommendation_suggestions():
+    """Parse LLM response into list of method, confidence, explanation."""
+    from services.llm_service import parse_recommendation_suggestions
+
+    raw = '{"suggestions": [{"method": "buffer(0)", "confidence": 0.9, "explanation": "Fix invalid polygon."}]}'
+    out = parse_recommendation_suggestions(raw)
+    assert len(out) == 1
+    assert out[0]["method"] == "buffer(0)"
+    assert out[0]["confidence"] == 0.9
+    assert "Fix invalid" in out[0]["explanation"]
+
+    assert parse_recommendation_suggestions(None) == []
+    assert parse_recommendation_suggestions("not json") == []
+

--- a/backend/tests/test_recommendation_agent.py
+++ b/backend/tests/test_recommendation_agent.py
@@ -1,0 +1,113 @@
+"""Tests for agents.recommendation_agent (issue #87)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.models import GeometryIssue
+from agents.recommendation_agent import run as recommendation_agent_run
+
+
+def test_run_with_no_issues_returns_empty_corrections():
+    """When state has no issues, return empty corrections list."""
+    state = {"dataset_id": "test", "issues": [], "corrections": []}
+    result = recommendation_agent_run(state)
+    assert "corrections" in result
+    assert result["corrections"] == []
+
+
+def test_run_with_none_issues_returns_empty_corrections():
+    """When state["issues"] is missing/None, return empty corrections."""
+    state = {"dataset_id": "test"}
+    result = recommendation_agent_run(state)
+    assert result["corrections"] == []
+
+
+def test_run_returns_rule_based_corrections_for_issues():
+    """Without LLM, agent returns one CorrectionSuggestion per issue with rule-based method/confidence/explanation."""
+    issues = [
+        GeometryIssue(feature_id=0, type="self_intersection", severity="critical", location=None, description="Self-intersecting ring"),
+        GeometryIssue(feature_id=1, type="attribute_typo", severity="warning", location=None, description="Field 'name': Use 'Main Street'"),
+    ]
+    state = {"issues": issues}
+    result = recommendation_agent_run(state)
+
+    assert "corrections" in result
+    corrections = result["corrections"]
+    assert len(corrections) == 2
+
+    assert corrections[0]["issue_index"] == 0
+    assert corrections[0]["method"] == "buffer(0)"
+    assert 0 <= corrections[0]["confidence"] <= 1
+    assert "buffer" in (corrections[0]["explanation"] or "").lower()
+
+    assert corrections[1]["issue_index"] == 1
+    assert "suggested" in (corrections[1]["method"] or "").lower() or "apply" in (corrections[1]["method"] or "").lower()
+    assert 0 <= corrections[1]["confidence"] <= 1
+
+
+def test_run_self_intersection_gets_buffer_suggestion():
+    """Rule-based: self_intersection issue yields buffer(0) and high confidence."""
+    state = {
+        "issues": [
+            GeometryIssue(feature_id=5, type="self_intersection", severity="critical", location=[0, 0], description="Invalid"),
+        ],
+    }
+    result = recommendation_agent_run(state)
+    assert len(result["corrections"]) == 1
+    c = result["corrections"][0]
+    assert c["method"] == "buffer(0)"
+    assert c["confidence"] == 0.9
+    assert c["issue_index"] == 0
+
+
+def test_run_with_llm_uses_llm_suggestions():
+    """When LLM is provided and returns suggestions, those are used instead of rules."""
+    issues = [
+        GeometryIssue(feature_id=0, type="self_intersection", severity="critical", location=None, description="Bad"),
+    ]
+    state = {"issues": issues}
+    mock_llm = MagicMock()
+
+    mock_suggestions = [
+        {"method": "custom_fix", "confidence": 0.95, "explanation": "LLM-generated suggestion."},
+    ]
+
+    with patch("agents.recommendation_agent.get_recommendation_suggestions_from_llm", return_value=mock_suggestions):
+        result = recommendation_agent_run(state, llm=mock_llm)
+
+    assert len(result["corrections"]) == 1
+    assert result["corrections"][0]["method"] == "custom_fix"
+    assert result["corrections"][0]["confidence"] == 0.95
+    assert "LLM-generated" in result["corrections"][0]["explanation"]
+    assert result["corrections"][0]["issue_index"] == 0
+
+
+def test_run_llm_failure_falls_back_to_rules():
+    """When LLM is provided but raises, fall back to rule-based suggestions."""
+    issues = [
+        GeometryIssue(feature_id=0, type="self_intersection", severity="critical", location=None, description="Bad"),
+    ]
+    state = {"issues": issues}
+    mock_llm = MagicMock()
+
+    with patch("agents.recommendation_agent.get_recommendation_suggestions_from_llm", side_effect=RuntimeError("API error")):
+        result = recommendation_agent_run(state, llm=mock_llm)
+
+    assert len(result["corrections"]) == 1
+    assert result["corrections"][0]["method"] == "buffer(0)"
+    assert result["corrections"][0]["issue_index"] == 0
+
+
+def test_run_correction_schema_compatible_with_apply_corrections():
+    """Each correction has method, confidence, explanation, issue_index (CorrectionSuggestion shape)."""
+    state = {
+        "issues": [
+            GeometryIssue(feature_id=0, type="topology_overlap", severity="warning", location=None, description="Overlap"),
+        ],
+    }
+    result = recommendation_agent_run(state)
+    c = result["corrections"][0]
+    assert "method" in c and isinstance(c["method"], str)
+    assert "confidence" in c and isinstance(c["confidence"], (int, float)) and 0 <= c["confidence"] <= 1
+    assert "explanation" in c and isinstance(c["explanation"], str)
+    assert "issue_index" in c and c["issue_index"] == 0


### PR DESCRIPTION
## Summary
Implements the **Recommendation Agent** so it consumes aggregated issues from state, generates a suggested fix per issue (method, confidence, natural-language explanation), uses **GPT-4** when an LLM is provided and **rule-based fallbacks** otherwise, and outputs structured **CorrectionSuggestion** entries compatible with the apply-corrections API (issue **#87**, sub-issue of **#9**).

## Related issues
- Closes #87
- Parent: #9 (Recommendation generation)
- Builds on: #86 (suggestion schema and apply-corrections compatibility)

## Changes

### LLM service (`backend/services/llm_service.py`)
- **build_recommendation_prompt(issues)** — Builds a prompt from issue list (type, severity, description); asks for JSON `suggestions`: `[{ method, confidence, explanation }, ...]` in the same order.
- **parse_recommendation_suggestions(raw)** — Parses LLM response into list of `{ method, confidence, explanation }`; safe defaults on parse error.
- **get_recommendation_suggestions_from_llm(issues, *, llm=None)** — Calls LLM (or default ChatOpenAI), parses and pads to match `len(issues)`.

### Recommendation agent (`backend/agents/recommendation_agent.py`)
- **run(state, *, llm=None)**:
  - Reads **state["issues"]** (geometry, attribute, topology).
  - Returns **{"corrections": []}** when there are no issues.
  - When **llm** is provided: calls **get_recommendation_suggestions_from_llm**, maps to **CorrectionSuggestion** (method, confidence, explanation, **issue_index**); on LLM error or short result, falls back to rule-based.
  - When **llm** is not provided: uses **rule-based** suggestions only.
- **Rule-based mapping** (e.g. self_intersection → buffer(0) 0.9, topology_overlap → merge/clip 0.7, attribute_* → apply suggested value 0.85, etc.).
- Returns **{"corrections": [CorrectionSuggestion.model_dump(), ...]}** compatible with apply-corrections API (#86).

### Tests
- **test_recommendation_agent.py** (7 tests): no issues → empty corrections; rule-based corrections and schema; self_intersection → buffer(0); LLM mock → LLM suggestions used; LLM failure → rule fallback; CorrectionSuggestion shape.
- **test_llm_service.py** (2 new): build_recommendation_prompt content; parse_recommendation_suggestions.

## Acceptance criteria (from #87)
- [x] Recommendation Agent consumes state["issues"] (geometry, attribute, topology).
- [x] Generate suggested fix per issue: method, confidence, natural-language explanation.
- [x] Use GPT-4 for context-aware suggestions where applicable (when llm is provided).
- [x] Output structured suggestions (state["corrections"]) compatible with apply-corrections API.
- [x] Add basic unit tests (mocked LLM and rule-based fixtures).