### PR TITLE
docs(#88): Integrate Recommendation Agent with orchestrator and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,15 @@ The **Topology Agent** node (`agents/topology_agent.run`, issue #81) is wired in
    - **description**: human-readable text (e.g. "Overlap with feature X", "Gap in polygon coverage").
 4. Returns **{"issues": existing + new_topology_issues}**. All issues (geometry, attribute, topology) are accumulated in state and considered by **\_route_by_severity** for conditional routing (e.g. any critical topology issue routes to apply_corrections).
 
+### **Recommendation Agent implementation**
+
+The **Recommendation Agent** node (`agents/recommendation_agent.run`, issue #87) is wired in the orchestrator as the `generate_recommendations` node (real implementation, not a stub). It:
+
+1. Reads **state["issues"]** (aggregated geometry, attribute, and topology issues).
+2. For each issue, generates a suggested fix: **method** (e.g. `buffer(0)`, "apply suggested value"), **confidence** (0–1), and **explanation** (natural-language). Uses GPT-4 when an LLM is provided; otherwise uses rule-based fallbacks (e.g. self_intersection → buffer(0), topology_overlap → merge/clip).
+3. Returns **{"corrections": [...]}** where each item is a **CorrectionSuggestion** (method, confidence, explanation, **issue_index**). state["corrections"] is merged into state; the **apply_corrections** node receives it (stub until correction application is implemented), and the validation API returns corrections in **ValidationResult.corrections**.
+4. Suggestions are compatible with the apply-corrections API (issue #86): client can approve/reject by issue_index.
+
 ### **Agent Responsibilities**
 
 | Agent | Input | Output | Tools Used |
@@ -553,7 +562,7 @@ The **Topology Agent** node (`agents/topology_agent.run`, issue #81) is wired in
 | **Geometry Agent** | Feature geometries | Invalid geometry list | Shapely, core.validation |
 | **Attribute Agent** | Feature attributes (sampled) | Inconsistency report (GeometryIssue) | GPT-4 (LangChain), attribute_extractor, llm_service |
 | **Topology Agent** | state["dataset_path"] (GeoDataFrame) | Topology violations as GeometryIssue (feature_id, type, severity, location, description) | GeoPandas, core.topology (gaps, overlaps, connectivity) |
-| **Recommendation Agent** | All issues | Correction suggestions | GPT-4, domain knowledge |
+| **Recommendation Agent** | state["issues"] (all geometry, attribute, topology issues) | state["corrections"] as CorrectionSuggestion (method, confidence, explanation, issue_index) | GPT-4 (optional), rule-based fallbacks, llm_service |
 
 ---
 

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -17,6 +17,14 @@ All issues—geometry, attribute, and topology—are accumulated in state["issue
 considered by _route_by_severity for conditional routing (e.g. any critical topology
 issue routes to apply_corrections).
 
+Recommendation Agent (issue #87, #88): The generate_recommendations node uses the real
+implementation (agents.recommendation_agent.run), not a stub. It reads state["issues"],
+produces one CorrectionSuggestion per issue (method, confidence, explanation, issue_index)
+via GPT-4 when an LLM is provided or rule-based fallbacks, and returns
+{"corrections": [...]}. state["corrections"] is merged into state; the apply_corrections
+node receives it (stub does not apply fixes yet), and the validation API returns
+corrections in ValidationResult.
+
 Routing logic (after generate_recommendations):
 - If any issue has severity "critical" -> apply_corrections node (stub; apply fixes when implemented).
 - Otherwise -> END (review path; no automatic corrections).
@@ -85,7 +93,7 @@ def _build_graph() -> Any:
     workflow_builder.add_node("geometry_validation", _geometry_validation_node)
     workflow_builder.add_node("attribute_validation", attribute_validation)
     workflow_builder.add_node("topology_validation", topology_validation)  # real impl: agents.topology_agent.run
-    workflow_builder.add_node("generate_recommendations", generate_recommendations)
+    workflow_builder.add_node("generate_recommendations", generate_recommendations)  # real impl: agents.recommendation_agent.run
     workflow_builder.add_node("apply_corrections", _apply_corrections_node)
 
     workflow_builder.set_entry_point("geometry_validation")


### PR DESCRIPTION
## Summary
Documents and confirms the **Recommendation Agent** integration in the LangGraph orchestrator and updates the README with Recommendation Agent implementation details (issue **#88**, sub-issue of **#9**).

## Related issues
- Closes #88
- Parent: #9 (Recommendation generation)
- Builds on: #87 (Recommendation Agent implementation), #86 (suggestion schema)

## Changes

### Orchestrator (`backend/agents/orchestrator.py`)
- **Module docstring**: Added **Recommendation Agent (issue #87, #88)** paragraph: the `generate_recommendations` node uses the **real implementation** (`agents.recommendation_agent.run`), not a stub. It reads state["issues"], produces one CorrectionSuggestion per issue (method, confidence, explanation, issue_index) via GPT-4 or rule-based fallbacks, and returns `{"corrections": [...]}`. state["corrections"] is merged into state; the apply_corrections node receives it (stub until correction application is implemented), and the validation API returns corrections in ValidationResult.
- **Inline comment** at the recommendation node: `# real impl: agents.recommendation_agent.run`.

### README (`README.md`)
- **New subsection: "Recommendation Agent implementation"** (after Topology Agent):
  - Input: state["issues"] (aggregated geometry, attribute, topology issues).
  - Behavior: one suggested fix per issue (method, confidence, explanation); GPT-4 when LLM provided, rule-based fallbacks otherwise.
  - Output: `{"corrections": [...]}` as CorrectionSuggestion (method, confidence, explanation, issue_index); state merge; apply_corrections receives it; API returns ValidationResult.corrections.
  - Compatibility with apply-corrections API (approve/reject by issue_index).
- **Agent Responsibilities table**: Recommendation Agent row updated with Input (state["issues"]), Output (state["corrections"] as CorrectionSuggestion with method, confidence, explanation, issue_index), Tools (GPT-4 optional, rule-based fallbacks, llm_service).

## Acceptance criteria (from #88)
- [x] Confirm `generate_recommendations` node uses the real Recommendation Agent implementation (not stub).
- [x] Confirm state["corrections"] is produced by the agent and consumed by apply_corrections / API where applicable.
- [x] Update README Agent Workflow (and Agent Responsibilities table) to describe the Recommendation Agent: inputs, outputs, and how suggestions are structured (method, confidence, explanation).