### PR TITLE
feat(#94): Add filterable IssuesPanel for dashboard

### DIFF
--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -3,41 +3,9 @@ import { CalcitePanel } from "@esri/calcite-components-react";
 
 import { MapViewer } from "../Map/MapViewer";
 import { SummaryStats } from "./SummaryStats";
+import { IssuesPanel } from "./IssuesPanel";
 import { useApp } from "../../context/AppContext";
 import type { GeometryIssue } from "../../types/api";
-
-type IssuesPanelProps = {
-  issues: GeometryIssue[];
-  onSelectIssue: (issue: GeometryIssue | null) => void;
-};
-
-function IssuesPanel({ issues, onSelectIssue }: IssuesPanelProps) {
-  if (!issues.length) {
-    return <p className="empty-state">No validation issues yet. Run validation to see results.</p>;
-  }
-
-  return (
-    <ul className="issues-panel-list" aria-label="Validation issues">
-      {issues.map((issue, index) => (
-        <li key={index}>
-          <button
-            type="button"
-            className="issues-panel-item"
-            onClick={() => onSelectIssue(issue)}
-          >
-            <span className="issues-panel-item__type">{issue.type}</span>
-            <span className="issues-panel-item__severity">{issue.severity}</span>
-            <span className="issues-panel-item__feature">
-              {issue.feature_id !== undefined && issue.feature_id !== null
-                ? `Feature ${issue.feature_id}`
-                : "Dataset-level issue"}
-            </span>
-          </button>
-        </li>
-      ))}
-    </ul>
-  );
-}
 
 type DetailViewProps = {
   issue: GeometryIssue | null;

--- a/frontend/src/components/Dashboard/IssuesPanel.tsx
+++ b/frontend/src/components/Dashboard/IssuesPanel.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from "react";
+import {
+  CalciteLabel,
+  CalciteSegmentedControl,
+  CalciteSegmentedControlItem,
+  CalciteInput,
+} from "@esri/calcite-components-react";
+
+import type { GeometryIssue } from "../../types/api";
+
+export type IssuesPanelProps = {
+  issues: GeometryIssue[];
+  onSelectIssue: (issue: GeometryIssue | null) => void;
+};
+
+type TypeFilter = "all" | "geometry" | "attribute" | "topology";
+type SeverityFilter = "all" | "critical" | "warning";
+
+function categorizeType(type: string): TypeFilter {
+  if (type.startsWith("attribute_")) return "attribute";
+  if (type.startsWith("topology_")) return "topology";
+  return "geometry";
+}
+
+export function IssuesPanel({ issues, onSelectIssue }: IssuesPanelProps) {
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const [featureFilter, setFeatureFilter] = useState<string>("");
+
+  const filteredIssues = useMemo(() => {
+    return issues.filter((issue) => {
+      const t = categorizeType(issue.type || "");
+      if (typeFilter !== "all" && t !== typeFilter) return false;
+
+      const sev = (issue.severity || "").toLowerCase();
+      if (severityFilter === "critical" && sev !== "critical") return false;
+      if (severityFilter === "warning" && sev !== "warning") return false;
+
+      if (featureFilter.trim()) {
+        const idStr =
+          issue.feature_id !== undefined && issue.feature_id !== null
+            ? String(issue.feature_id)
+            : "";
+        if (!idStr.includes(featureFilter.trim())) return false;
+      }
+
+      return true;
+    });
+  }, [issues, typeFilter, severityFilter, featureFilter]);
+
+  const handleClearFilters = () => {
+    setTypeFilter("all");
+    setSeverityFilter("all");
+    setFeatureFilter("");
+  };
+
+  const handleRowClick = (issue: GeometryIssue) => {
+    onSelectIssue(issue);
+  };
+
+  return (
+    <div className="issues-panel">
+      <div className="issues-panel__filters">
+        <CalciteLabel>
+          Type
+          <CalciteSegmentedControl
+            value={typeFilter}
+            onCalciteSegmentedControlChange={(event) => {
+              const value = (event.target as HTMLCalciteSegmentedControlElement).value as TypeFilter;
+              setTypeFilter(value);
+            }}
+          >
+            <CalciteSegmentedControlItem value="all">All</CalciteSegmentedControlItem>
+            <CalciteSegmentedControlItem value="geometry">Geometry</CalciteSegmentedControlItem>
+            <CalciteSegmentedControlItem value="attribute">Attribute</CalciteSegmentedControlItem>
+            <CalciteSegmentedControlItem value="topology">Topology</CalciteSegmentedControlItem>
+          </CalciteSegmentedControl>
+        </CalciteLabel>
+
+        <CalciteLabel>
+          Severity
+          <CalciteSegmentedControl
+            value={severityFilter}
+            onCalciteSegmentedControlChange={(event) => {
+              const value = (event.target as HTMLCalciteSegmentedControlElement)
+                .value as SeverityFilter;
+              setSeverityFilter(value);
+            }}
+          >
+            <CalciteSegmentedControlItem value="all">All</CalciteSegmentedControlItem>
+            <CalciteSegmentedControlItem value="critical">Critical</CalciteSegmentedControlItem>
+            <CalciteSegmentedControlItem value="warning">Warning</CalciteSegmentedControlItem>
+          </CalciteSegmentedControl>
+        </CalciteLabel>
+
+        <CalciteLabel>
+          Feature ID
+          <CalciteInput
+            value={featureFilter}
+            placeholder="Filter by feature id"
+            onCalciteInputInput={(event) => {
+              const value = (event.target as HTMLCalciteInputElement).value ?? "";
+              setFeatureFilter(value);
+            }}
+          />
+        </CalciteLabel>
+
+        <button type="button" className="issues-panel__clear" onClick={handleClearFilters}>
+          Clear filters
+        </button>
+      </div>
+
+      {!filteredIssues.length ? (
+        <p className="empty-state">No issues match the current filters.</p>
+      ) : (
+        <ul className="issues-panel-list" aria-label="Validation issues">
+          {filteredIssues.map((issue, index) => (
+            <li key={index}>
+              <button
+                type="button"
+                className="issues-panel-item"
+                onClick={() => handleRowClick(issue)}
+              >
+                <span className="issues-panel-item__type">{issue.type}</span>
+                <span className="issues-panel-item__severity">{issue.severity}</span>
+                <span className="issues-panel-item__feature">
+                  {issue.feature_id !== undefined && issue.feature_id !== null
+                    ? `Feature ${String(issue.feature_id)}`
+                    : "Dataset-level issue"}
+                </span>
+                {issue.description && (
+                  <span className="issues-panel-item__description">
+                    {issue.description.length > 80
+                      ? `${issue.description.slice(0, 77)}…`
+                      : issue.description}
+                  </span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
Implements a **filterable IssuesPanel** for the validation dashboard that lists validation issues and supports filtering by type, severity, and feature ID (issue **#94**, sub-issue of **#10**).

## Related issues
- Closes #94
- Parent: #10 (Full dashboard implementation)

## Changes

### New IssuesPanel component (`frontend/src/components/Dashboard/IssuesPanel.tsx`)
- Props:
  - `issues: GeometryIssue[]`
  - `onSelectIssue: (issue: GeometryIssue | null) => void`
- **Filtering features**:
  - **Type filter** (`all | geometry | attribute | topology`):
    - `geometry` = non-prefixed types
    - `attribute` = types starting with `attribute_`
    - `topology` = types starting with `topology_`
    - Implemented with `CalciteSegmentedControl`.
  - **Severity filter** (`all | critical | warning`):
    - Filters on `issue.severity.toLowerCase()`.
    - Implemented with `CalciteSegmentedControl`.
  - **Feature filter**:
    - `CalciteInput` textbox to filter issues by `feature_id` (string containment match).
- **Filter logic**:
  - Uses `useMemo` to derive `filteredIssues` based on the three filters.
  - "Clear filters" button resets all filters to defaults.
- **Issue list rendering**:
  - If no filtered issues: shows `"No issues match the current filters."`.
  - Otherwise renders a `<ul>` of buttons, each showing:
    - `type`
    - `severity`
    - `Feature X` or `Dataset-level issue`
    - Optional description preview (truncated to ~80 chars).
  - Clicking a row calls `onSelectIssue(issue)` to drive selection in the dashboard (Detail View and future map highlight logic).
- **Calcite usage**:
  - `CalciteLabel`, `CalciteSegmentedControl`, `CalciteSegmentedControlItem`, and `CalciteInput` used for filters to stay aligned with Calcite design.

### Dashboard wiring (`frontend/src/components/Dashboard/DashboardPage.tsx`)
- Imports and uses the new IssuesPanel:
  - `import { IssuesPanel } from "./IssuesPanel";`
- Replaces the previous inline issues list with:
  ```tsx
  <CalcitePanel heading="Issues" className="dashboard-panel dashboard-panel--issues">
    <IssuesPanel issues={validationIssues} onSelectIssue={setSelectedIssue} />
  </CalcitePanel>
  ```
- Continues to use `selectedIssue` state and passes it to `DetailView`, so selecting an issue in IssuesPanel updates the Detail View as required by #94.

## Acceptance criteria (from #94)
- [x] List issues from validation result (type, severity, feature_id, description preview).
- [x] Filter by issue type (geometry, attribute_*, topology_*).
- [x] Filter by severity (critical, warning).
- [x] Filter by feature (feature_id).
- [x] Selection of an issue updates Detail View and is wired to support map highlight behavior.
- [x] Uses Calcite components for list/filter controls.