### PR TITLE
feat(#95): Add DetailView with issue details and suggested fix

### DIFF
--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -4,48 +4,12 @@ import { CalcitePanel } from "@esri/calcite-components-react";
 import { MapViewer } from "../Map/MapViewer";
 import { SummaryStats } from "./SummaryStats";
 import { IssuesPanel } from "./IssuesPanel";
+import { DetailView } from "./DetailView";
 import { useApp } from "../../context/AppContext";
-import type { GeometryIssue } from "../../types/api";
-
-type DetailViewProps = {
-  issue: GeometryIssue | null;
-};
-
-function DetailView({ issue }: DetailViewProps) {
-  if (!issue) {
-    return <p className="empty-state">Select an issue to see its details.</p>;
-  }
-
-  return (
-    <div className="detail-view">
-      <p>
-        <strong>Type:</strong> {issue.type}
-      </p>
-      <p>
-        <strong>Severity:</strong> {issue.severity}
-      </p>
-      {issue.feature_id !== undefined && issue.feature_id !== null && (
-        <p>
-          <strong>Feature:</strong> {String(issue.feature_id)}
-        </p>
-      )}
-      {issue.location && (
-        <p>
-          <strong>Location:</strong> [{issue.location.join(", ")}]
-        </p>
-      )}
-      {issue.description && (
-        <p>
-          <strong>Description:</strong> {issue.description}
-        </p>
-      )}
-    </div>
-  );
-}
 
 export function DashboardPage() {
   const { currentDataset, validationIssues } = useApp();
-  const [selectedIssue, setSelectedIssue] = useState<GeometryIssue | null>(null);
+  const [selectedIssueIndex, setSelectedIssueIndex] = useState<number | null>(null);
 
   const totalFeatures =
     typeof currentDataset?.feature_count === "number" ? currentDataset.feature_count : null;
@@ -72,7 +36,7 @@ export function DashboardPage() {
           </CalcitePanel>
 
           <CalcitePanel heading="Issues" className="dashboard-panel dashboard-panel--issues">
-            <IssuesPanel issues={validationIssues} onSelectIssue={setSelectedIssue} />
+            <IssuesPanel issues={validationIssues} onSelectIssueIndex={setSelectedIssueIndex} />
           </CalcitePanel>
 
           <CalcitePanel heading="Summary" className="dashboard-panel dashboard-panel--summary">
@@ -80,7 +44,7 @@ export function DashboardPage() {
           </CalcitePanel>
 
           <CalcitePanel heading="Issue details" className="dashboard-panel dashboard-panel--detail">
-            <DetailView issue={selectedIssue} />
+            <DetailView selectedIssueIndex={selectedIssueIndex} />
           </CalcitePanel>
         </div>
       )}

--- a/frontend/src/components/Dashboard/DetailView.tsx
+++ b/frontend/src/components/Dashboard/DetailView.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+
+import { useApp } from "../../context/AppContext";
+import type { CorrectionSuggestion, GeometryIssue } from "../../types/api";
+
+export type DetailViewProps = {
+  selectedIssueIndex: number | null;
+};
+
+export function DetailView({ selectedIssueIndex }: DetailViewProps) {
+  const { validationResult } = useApp();
+
+  const issue: GeometryIssue | null =
+    selectedIssueIndex !== null && validationResult?.issues?.[selectedIssueIndex]
+      ? validationResult.issues[selectedIssueIndex]
+      : null;
+
+  const suggestion: CorrectionSuggestion | null = useMemo(() => {
+    if (selectedIssueIndex === null || !validationResult?.corrections) return null;
+    return (
+      validationResult.corrections.find(
+        (c) => typeof c.issue_index === "number" && c.issue_index === selectedIssueIndex,
+      ) ?? null
+    );
+  }, [selectedIssueIndex, validationResult?.corrections]);
+
+  if (!issue) {
+    return <p className="empty-state">Select an issue to see its details and suggested fix.</p>;
+  }
+
+  return (
+    <div className="detail-view">
+      <div className="detail-view__section">
+        <h3 className="detail-view__heading">Issue details</h3>
+        <p>
+          <strong>Type:</strong> {issue.type}
+        </p>
+        <p>
+          <strong>Severity:</strong> {issue.severity}
+        </p>
+        {issue.feature_id !== undefined && issue.feature_id !== null && (
+          <p>
+            <strong>Feature:</strong> {String(issue.feature_id)}
+          </p>
+        )}
+        {issue.location && (
+          <p>
+            <strong>Location:</strong> [{issue.location.join(", ")}]
+          </p>
+        )}
+        {issue.description && (
+          <p>
+            <strong>Description:</strong> {issue.description}
+          </p>
+        )}
+      </div>
+
+      <div className="detail-view__section">
+        <h3 className="detail-view__heading">Suggested fix</h3>
+        {!suggestion ? (
+          <p className="detail-view__no-suggestion">
+            No suggested fix is available for this issue. You can review it manually.
+          </p>
+        ) : (
+          <>
+            <p>
+              <strong>Method:</strong> {suggestion.method}
+            </p>
+            <p>
+              <strong>Confidence:</strong> {(suggestion.confidence * 100).toFixed(0)}%
+            </p>
+            <p>
+              <strong>Explanation:</strong> {suggestion.explanation}
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/Dashboard/IssuesPanel.tsx
+++ b/frontend/src/components/Dashboard/IssuesPanel.tsx
@@ -10,7 +10,7 @@ import type { GeometryIssue } from "../../types/api";
 
 export type IssuesPanelProps = {
   issues: GeometryIssue[];
-  onSelectIssue: (issue: GeometryIssue | null) => void;
+  onSelectIssueIndex: (index: number | null) => void;
 };
 
 type TypeFilter = "all" | "geometry" | "attribute" | "topology";
@@ -22,13 +22,15 @@ function categorizeType(type: string): TypeFilter {
   return "geometry";
 }
 
-export function IssuesPanel({ issues, onSelectIssue }: IssuesPanelProps) {
+export function IssuesPanel({ issues, onSelectIssueIndex }: IssuesPanelProps) {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
   const [featureFilter, setFeatureFilter] = useState<string>("");
 
-  const filteredIssues = useMemo(() => {
-    return issues.filter((issue) => {
+  const filtered = useMemo(() => {
+    return issues
+      .map((issue, index) => ({ issue, index }))
+      .filter(({ issue }) => {
       const t = categorizeType(issue.type || "");
       if (typeFilter !== "all" && t !== typeFilter) return false;
 
@@ -54,8 +56,8 @@ export function IssuesPanel({ issues, onSelectIssue }: IssuesPanelProps) {
     setFeatureFilter("");
   };
 
-  const handleRowClick = (issue: GeometryIssue) => {
-    onSelectIssue(issue);
+  const handleRowClick = (index: number) => {
+    onSelectIssueIndex(index);
   };
 
   return (
@@ -110,16 +112,16 @@ export function IssuesPanel({ issues, onSelectIssue }: IssuesPanelProps) {
         </button>
       </div>
 
-      {!filteredIssues.length ? (
+      {!filtered.length ? (
         <p className="empty-state">No issues match the current filters.</p>
       ) : (
         <ul className="issues-panel-list" aria-label="Validation issues">
-          {filteredIssues.map((issue, index) => (
+          {filtered.map(({ issue, index }) => (
             <li key={index}>
               <button
                 type="button"
                 className="issues-panel-item"
-                onClick={() => handleRowClick(issue)}
+                onClick={() => handleRowClick(index)}
               >
                 <span className="issues-panel-item__type">{issue.type}</span>
                 <span className="issues-panel-item__severity">{issue.severity}</span>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -11,6 +11,7 @@ export type GeometryIssue = {
 export type ValidationResult = {
   dataset_id: string;
   issues: GeometryIssue[];
+  corrections?: CorrectionSuggestion[] | null;
 };
 
 export type UploadResponse = {
@@ -19,4 +20,11 @@ export type UploadResponse = {
   /** Optional total feature count for the dataset (from upload metadata). */
   feature_count?: number;
   bounds?: number[] | null;
+};
+
+export type CorrectionSuggestion = {
+  method: string;
+  confidence: number;
+  explanation: string;
+  issue_index: number;
 };


### PR DESCRIPTION
## Summary
Implements a **DetailView** component for the dashboard that shows full details for the selected issue and, when available, the **suggested fix** (method, confidence, explanation) from the Recommendation Agent (issue **#95**, sub-issue of **#10**).

## Related issues
- Closes #95
- Parent: #10 (Full dashboard implementation)

## Changes

### Types (`frontend/src/types/api.ts`)
- Aligns frontend `ValidationResult` with backend by adding an optional `corrections` field:
  ```ts
  export type ValidationResult = {
    dataset_id: string;
    issues: GeometryIssue[];
    corrections?: CorrectionSuggestion[] | null;
  };
  ```
- Adds **`CorrectionSuggestion`** type mirroring backend `CorrectionSuggestion`:
  - `method: string`
  - `confidence: number`
  - `explanation: string`
  - `issue_index: number`

### DetailView component (`frontend/src/components/Dashboard/DetailView.tsx`)
- New `DetailView` component:
  - Props: `selectedIssueIndex: number | null`.
  - Uses `useApp()` to access `validationResult`.
  - Resolves the current **issue** as `validationResult.issues[selectedIssueIndex]` when index is valid; otherwise treats as no selection.
  - Resolves the matching **suggested fix** from `validationResult.corrections` by comparing `issue_index` to `selectedIssueIndex`.
- **Rendering behavior:**
  - If no issue is selected (no index or missing validation result): shows an empty state message:
    > "Select an issue to see its details and suggested fix."
  - If an issue is selected:
    - Shows issue details:
      - Type, severity
      - Feature (stringified `feature_id`)
      - Location (formatted `[lng, lat]` when present)
      - Description
    - Suggested fix section:
      - If a `CorrectionSuggestion` exists:
        - Method (short fix name)
        - Confidence shown as a percentage (e.g. 0.85 → 85%)
        - Explanation
      - If none exists:
        - Message indicating no suggested fix is available.

### IssuesPanel selection by index (`frontend/src/components/Dashboard/IssuesPanel.tsx`)
- Updates props to select by **issue index** instead of directly passing issue objects:
  - `onSelectIssueIndex: (index: number | null) => void`.
- Filters `issues` into `{ issue, index }` pairs so the original index is preserved through filters.
- Row click now calls `onSelectIssueIndex(index)`.
- This ensures the selected index lines up with `ValidationResult.issues[index]` and `corrections.issue_index`, enabling DetailView to find the right suggestion.

### Dashboard wiring (`frontend/src/components/Dashboard/DashboardPage.tsx`)
- Uses index-based selection for DetailView:
  - State: `const [selectedIssueIndex, setSelectedIssueIndex] = useState<number | null>(null);`
  - Issues panel:
    ```tsx
    <CalcitePanel heading="Issues" className="dashboard-panel dashboard-panel--issues">
      <IssuesPanel issues={validationIssues} onSelectIssueIndex={setSelectedIssueIndex} />
    </CalcitePanel>
    ```
  - Detail panel:
    ```tsx
    <CalcitePanel heading="Issue details" className="dashboard-panel dashboard-panel--detail">
      <DetailView selectedIssueIndex={selectedIssueIndex} />
    </CalcitePanel>
    ```
- Keeps existing map and SummaryStats wiring from previous issues (#93, #96) intact.

## Acceptance criteria (from #95)
- [x] Display selected issue: `feature_id`, `type`, `severity`, `location`, `description`.
- [x] Display suggested fix when available: `method`, `confidence`, `explanation` (from `corrections` by `issue_index`).
- [x] Clear state when no issue is selected (empty-state messaging).
- [x] Calcite typography and panels via the surrounding `CalcitePanel` structure in the dashboard.