### PR TITLE
feat(#97): real-time dashboard validation updates

### DIFF
--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { CalcitePanel } from "@esri/calcite-components-react";
+import { CalcitePanel, CalciteButton, CalciteLoader } from "@esri/calcite-components-react";
 
 import { MapViewer } from "../Map/MapViewer";
 import { SummaryStats } from "./SummaryStats";
@@ -8,7 +8,13 @@ import { DetailView } from "./DetailView";
 import { useApp } from "../../context/AppContext";
 
 export function DashboardPage() {
-  const { currentDataset, validationIssues } = useApp();
+  const {
+    currentDataset,
+    validationIssues,
+    isValidating,
+    validationError,
+    handleValidate,
+  } = useApp();
   const [selectedIssueIndex, setSelectedIssueIndex] = useState<number | null>(null);
 
   const totalFeatures =
@@ -25,28 +31,52 @@ export function DashboardPage() {
           once validation has run.
         </p>
       ) : (
-        <div className="dashboard-grid">
-          <CalcitePanel heading={currentDataset.filename} className="dashboard-panel dashboard-panel--map">
-            <MapViewer
-              datasetId={currentDataset.dataset_id}
-              bounds={currentDataset.bounds ?? null}
-              layerTitle={currentDataset.filename}
-              validationIssues={validationIssues}
-            />
-          </CalcitePanel>
+        <>
+          <div className="dashboard-actions">
+            <CalciteButton
+              kind="brand"
+              onClick={handleValidate}
+              disabled={isValidating}
+              loading={isValidating}
+              label={isValidating ? "Validating…" : "Run validation"}
+            >
+              {isValidating ? "Validating…" : "Run validation"}
+            </CalciteButton>
+            {isValidating && (
+              <div className="dashboard-validation-status" role="status" aria-live="polite">
+                <CalciteLoader scale="s" />
+                <span>Validation in progress. Issues and map will update when complete.</span>
+              </div>
+            )}
+            {validationError && (
+              <p className="status-message status-message--error" role="alert">
+                {validationError}
+              </p>
+            )}
+          </div>
+          <div className="dashboard-grid">
+            <CalcitePanel heading={currentDataset.filename} className="dashboard-panel dashboard-panel--map">
+              <MapViewer
+                datasetId={currentDataset.dataset_id}
+                bounds={currentDataset.bounds ?? null}
+                layerTitle={currentDataset.filename}
+                validationIssues={validationIssues}
+              />
+            </CalcitePanel>
 
-          <CalcitePanel heading="Issues" className="dashboard-panel dashboard-panel--issues">
-            <IssuesPanel issues={validationIssues} onSelectIssueIndex={setSelectedIssueIndex} />
-          </CalcitePanel>
+            <CalcitePanel heading="Issues" className="dashboard-panel dashboard-panel--issues">
+              <IssuesPanel issues={validationIssues} onSelectIssueIndex={setSelectedIssueIndex} />
+            </CalcitePanel>
 
-          <CalcitePanel heading="Summary" className="dashboard-panel dashboard-panel--summary">
-            <SummaryStats totalFeatures={totalFeatures} issues={validationIssues} />
-          </CalcitePanel>
+            <CalcitePanel heading="Summary" className="dashboard-panel dashboard-panel--summary">
+              <SummaryStats totalFeatures={totalFeatures} issues={validationIssues} />
+            </CalcitePanel>
 
-          <CalcitePanel heading="Issue details" className="dashboard-panel dashboard-panel--detail">
-            <DetailView selectedIssueIndex={selectedIssueIndex} />
-          </CalcitePanel>
-        </div>
+            <CalcitePanel heading="Issue details" className="dashboard-panel dashboard-panel--detail">
+              <DetailView selectedIssueIndex={selectedIssueIndex} />
+            </CalcitePanel>
+          </div>
+        </>
       )}
     </section>
   );

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,5 +1,12 @@
 import { createContext, useContext, useState, type ReactNode } from "react";
-import type { GeometryIssue, ValidationResult, UploadResponse } from "../types/api";
+import type {
+  GeometryIssue,
+  ValidationResult,
+  UploadResponse,
+  ValidationJobStatus,
+} from "../types/api";
+
+const POLL_INTERVAL_MS = 1500;
 
 type AppContextValue = {
   currentDataset: UploadResponse | null;
@@ -65,15 +72,36 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setValidationResult(null);
     setIsValidating(true);
     try {
-      const res = await fetch(`/api/v1/validate/${currentDataset.dataset_id}`);
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
+      const startRes = await fetch("/api/v1/validate/async", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dataset_id: currentDataset.dataset_id }),
+      });
+      if (!startRes.ok) {
+        const data = await startRes.json().catch(() => ({}));
         const detail =
-          typeof data.detail === "string" ? data.detail : data.detail?.detail ?? res.statusText;
+          typeof data.detail === "string" ? data.detail : data.detail?.detail ?? startRes.statusText;
         throw new Error(detail);
       }
-      const data = (await res.json()) as ValidationResult;
-      setValidationResult(data);
+      const { job_id } = (await startRes.json()) as ValidationJobStatus;
+
+      for (;;) {
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+        const jobRes = await fetch(`/api/v1/validate/jobs/${job_id}`);
+        if (!jobRes.ok) {
+          setValidationError("Failed to get validation status");
+          break;
+        }
+        const job = (await jobRes.json()) as ValidationJobStatus;
+        if (job.status === "completed" && job.result) {
+          setValidationResult(job.result);
+          break;
+        }
+        if (job.status === "failed") {
+          setValidationError(job.error ?? "Validation failed");
+          break;
+        }
+      }
     } catch (e) {
       setValidationError(e instanceof Error ? e.message : "Validation failed");
     } finally {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -183,6 +183,26 @@ calcite-shell .app-main {
   font-weight: 600;
 }
 
+.dashboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.dashboard-validation-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.dashboard-validation-status calcite-loader {
+  flex-shrink: 0;
+}
+
 .upload-label {
   display: block;
   margin-bottom: 0.75rem;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -28,3 +28,12 @@ export type CorrectionSuggestion = {
   explanation: string;
   issue_index: number;
 };
+
+/** Async validation job status (GET /validate/jobs/{job_id}). */
+export type ValidationJobStatus = {
+  job_id: string;
+  dataset_id: string;
+  status: "pending" | "running" | "completed" | "failed";
+  error?: string | null;
+  result?: ValidationResult | null;
+};


### PR DESCRIPTION
## Summary

This pull request implements **real-time dashboard updates when validation completes** for issue #97 (child of #10).

- Switches validation to use the async validation workflow (`POST /api/v1/validate/async` + `GET /api/v1/validate/jobs/{job_id}`) and wires it into the shared app context.
- Polls the validation job status until completion or failure, then updates the dashboard with the latest issues, corrections, and stats.
- Adds a dashboard-level validation control with Calcite loading/status UX so users see validation progress and updated content without a full page reload.

## Details

- **Async validation + polling**
  - `AppContext.handleValidate` now:
    - Sends a `POST /api/v1/validate/async` request with the current `dataset_id`.
    - Retrieves the returned `job_id` and polls `GET /api/v1/validate/jobs/{job_id}` at a fixed interval until the job reaches `completed` or `failed`.
    - On `completed`, updates `validationResult` in context so all consumers (map, issues panel, summary stats, detail view) automatically refresh with the new data.
    - On `failed`, surfaces the backend-provided error (if present) or a generic "Validation failed" message.
  - Introduces a strongly-typed `ValidationJobStatus` type in the frontend API models, mirroring the backend `ValidationJobStatus` shape (job id, dataset id, status, optional error, optional result).

- **Dashboard integration (real-time updates)**
  - `DashboardPage` now:
    - Uses `isValidating`, `validationError`, `validationIssues`, and `handleValidate` from context.
    - Renders a primary **"Run validation"** button at the top of the dashboard that triggers the async validation flow.
    - Shows a real-time status row while validation is running, indicating that the dashboard (issues, stats, map) will refresh when complete.
  - Because the dashboard components already consume `validationIssues` and `validationResult` from context, the map markers, issues panel, summary counts, and detail view all update automatically as soon as the async job finishes and the result is stored.

- **Calcite-based loading/status UX**
  - Adds a `CalciteButton` with `loading` and `disabled` states tied to `isValidating`.
  - Adds a compact `CalciteLoader` plus status text while validation is in progress.
  - Reuses the existing status message styles for error display on the dashboard.

## Testing

- Ran `npm run build` in the `frontend` to ensure the updated code type-checks and bundles successfully.
- Manually verified that:
  - Triggering validation from the dashboard starts the async job and shows a loading state.
  - When the job completes, issues and summary stats update without a full page reload.
  - Validation errors are surfaced on the dashboard when the backend returns an error.

## Related issues

- Closes #97
- Related to #10 (Full dashboard implementation)