### PR TITLE
feat(#104): POST /corrections/apply and dashboard apply flow

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -67,6 +67,17 @@ class ApplyCorrectionsRequest(BaseModel):
     )
 
 
+class ApplyCorrectionsResponse(BaseModel):
+    """Response from POST /corrections/apply (README + issue #104)."""
+
+    applied: int = Field(..., ge=0, description="Number of corrections approved for application")
+    skipped: int = Field(..., ge=0, description="Number of corrections rejected (skipped)")
+    download_url: Optional[str] = Field(
+        None,
+        description="Optional URL to download cleaned export when implemented; may point at dataset GeoJSON meanwhile",
+    )
+
+
 class ValidationResult(BaseModel):
     """Result of geometry validation for a dataset."""
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -5,7 +5,16 @@ import uuid
 
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
-from api.models import ErrorCode, ErrorResponse, UploadResponse, ValidationJobStatus, ValidateRequest, ValidationResult
+from api.models import (
+    ApplyCorrectionsRequest,
+    ApplyCorrectionsResponse,
+    ErrorCode,
+    ErrorResponse,
+    UploadResponse,
+    ValidationJobStatus,
+    ValidateRequest,
+    ValidationResult,
+)
 from core.config import settings
 from services.file_handler import (
     extract_zip_in_upload_dir,
@@ -296,3 +305,52 @@ async def get_dataset_geojson(dataset_id: str):
             },
         )
     return FileResponse(path, media_type="application/geo+json")
+
+
+@router.post(
+    "/corrections/apply",
+    response_model=ApplyCorrectionsResponse,
+    responses={
+        200: {"description": "Corrections applied (stub counts); export URL when available"},
+        400: {"description": "Invalid request body", "model": ErrorResponse},
+        404: {"description": "Dataset not found", "model": ErrorResponse},
+    },
+)
+async def apply_corrections(body: ApplyCorrectionsRequest):
+    """
+    Accept user approve/reject decisions per issue index (issue #104).
+
+    Validates dataset exists. Returns applied vs skipped counts. Actual geometry
+    mutation and cleaned-zip export can be extended later; download_url may reference
+    the dataset GeoJSON as an interim download when no separate export exists.
+    """
+    if not body.corrections:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "detail": "At least one correction decision is required.",
+                "code": "EMPTY_CORRECTIONS",
+            },
+        )
+
+    path = get_primary_vector_path(body.dataset_id)
+    if path is None or not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "detail": f"Dataset not found or no vector file: {body.dataset_id}",
+                "code": ErrorCode.DATASET_NOT_FOUND,
+            },
+        )
+
+    # Last entry wins if the same issue_index appears more than once.
+    by_index: dict[int, str] = {}
+    for item in body.corrections:
+        by_index[item.issue_index] = item.action
+
+    applied = sum(1 for a in by_index.values() if a == "approve")
+    skipped = sum(1 for a in by_index.values() if a == "reject")
+
+    download_url = f"/api/v1/datasets/{body.dataset_id}/geojson"
+
+    return ApplyCorrectionsResponse(applied=applied, skipped=skipped, download_url=download_url)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -26,3 +26,73 @@ def test_get_dataset_geojson_not_found(client, tmp_path, monkeypatch):
     assert response.status_code == 400
     data = response.json()
     assert data.get("detail", {}).get("code") == "DATASET_NOT_FOUND"
+
+
+def test_apply_corrections_empty_returns_400(client):
+    """POST /corrections/apply returns 400 when corrections list is empty."""
+    response = client.post(
+        "/api/v1/corrections/apply",
+        json={"dataset_id": "any", "corrections": []},
+    )
+    assert response.status_code == 400
+
+
+def test_apply_corrections_success(client, tmp_path, monkeypatch):
+    """POST /corrections/apply returns applied/skipped counts when dataset exists."""
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    dataset_id = "ds-apply"
+    (tmp_path / dataset_id).mkdir()
+    (tmp_path / dataset_id / "data.geojson").write_text('{"type":"FeatureCollection","features":[]}')
+
+    response = client.post(
+        "/api/v1/corrections/apply",
+        json={
+            "dataset_id": dataset_id,
+            "corrections": [
+                {"issue_index": 0, "action": "approve"},
+                {"issue_index": 1, "action": "reject"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] == 1
+    assert data["skipped"] == 1
+    assert dataset_id in (data.get("download_url") or "")
+
+
+def test_apply_corrections_duplicate_issue_index_last_wins(client, tmp_path, monkeypatch):
+    """Duplicate issue_index in body: last action wins for counts."""
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    dataset_id = "ds-dup"
+    (tmp_path / dataset_id).mkdir()
+    (tmp_path / dataset_id / "data.geojson").write_text('{"type":"FeatureCollection","features":[]}')
+
+    response = client.post(
+        "/api/v1/corrections/apply",
+        json={
+            "dataset_id": dataset_id,
+            "corrections": [
+                {"issue_index": 0, "action": "approve"},
+                {"issue_index": 0, "action": "reject"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] == 0
+    assert data["skipped"] == 1
+
+
+def test_apply_corrections_dataset_not_found(client, tmp_path, monkeypatch):
+    """POST /corrections/apply returns 404 when dataset has no vector file."""
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+
+    response = client.post(
+        "/api/v1/corrections/apply",
+        json={"dataset_id": "missing", "corrections": [{"issue_index": 0, "action": "approve"}]},
+    )
+
+    assert response.status_code == 404

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { CalcitePanel, CalciteButton, CalciteLoader } from "@esri/calcite-components-react";
 
 import { MapViewer } from "../Map/MapViewer";
@@ -6,19 +6,34 @@ import { SummaryStats } from "./SummaryStats";
 import { IssuesPanel } from "./IssuesPanel";
 import { DetailView } from "./DetailView";
 import { useApp } from "../../context/AppContext";
+import { buildApplyCorrectionsActions } from "../../utils/buildApplyCorrectionsRequest";
 
 export function DashboardPage() {
   const {
     currentDataset,
     validationIssues,
+    validationResult,
+    correctionDecisions,
     isValidating,
     validationError,
     handleValidate,
+    isApplyingCorrections,
+    applyCorrectionsError,
+    lastApplyCorrectionsResult,
+    handleApplyCorrections,
   } = useApp();
   const [selectedIssueIndex, setSelectedIssueIndex] = useState<number | null>(null);
 
   const totalFeatures =
     typeof currentDataset?.feature_count === "number" ? currentDataset.feature_count : null;
+
+  const applyActionsCount = useMemo(() => {
+    if (!validationResult) return 0;
+    return buildApplyCorrectionsActions(validationResult, correctionDecisions).length;
+  }, [validationResult, correctionDecisions]);
+
+  const canApplyCorrections =
+    Boolean(currentDataset?.dataset_id && validationResult && applyActionsCount > 0);
 
   return (
     <section className="page-section page-section--dashboard" aria-labelledby="dashboard-heading">
@@ -36,11 +51,24 @@ export function DashboardPage() {
             <CalciteButton
               kind="brand"
               onClick={handleValidate}
-              disabled={isValidating}
+              disabled={isValidating || isApplyingCorrections}
               loading={isValidating}
               label={isValidating ? "Validating…" : "Run validation"}
             >
               {isValidating ? "Validating…" : "Run validation"}
+            </CalciteButton>
+            <CalciteButton
+              kind="neutral"
+              onClick={handleApplyCorrections}
+              disabled={!canApplyCorrections || isValidating || isApplyingCorrections}
+              loading={isApplyingCorrections}
+              label={
+                isApplyingCorrections
+                  ? "Applying corrections…"
+                  : "Apply correction choices to the server"
+              }
+            >
+              {isApplyingCorrections ? "Applying…" : "Apply corrections"}
             </CalciteButton>
             {isValidating && (
               <div className="dashboard-validation-status" role="status" aria-live="polite">
@@ -48,9 +76,31 @@ export function DashboardPage() {
                 <span>Validation in progress. Issues and map will update when complete.</span>
               </div>
             )}
+            {isApplyingCorrections && (
+              <div className="dashboard-validation-status" role="status" aria-live="polite">
+                <CalciteLoader scale="s" />
+                <span>Sending your approve/reject choices to the API…</span>
+              </div>
+            )}
             {validationError && (
               <p className="status-message status-message--error" role="alert">
                 {validationError}
+              </p>
+            )}
+            {applyCorrectionsError && (
+              <p className="status-message status-message--error" role="alert">
+                {applyCorrectionsError}
+              </p>
+            )}
+            {lastApplyCorrectionsResult && (
+              <p className="status-message status-message--success" role="status">
+                Applied {lastApplyCorrectionsResult.applied}, skipped {lastApplyCorrectionsResult.skipped}.
+                {lastApplyCorrectionsResult.download_url ? (
+                  <>
+                    {" "}
+                    <a href={lastApplyCorrectionsResult.download_url}>Dataset download</a>
+                  </>
+                ) : null}
               </p>
             )}
           </div>

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -5,7 +5,9 @@ import type {
   UploadResponse,
   ValidationJobStatus,
   CorrectionDecision,
+  ApplyCorrectionsResponse,
 } from "../types/api";
+import { buildApplyCorrectionsActions } from "../utils/buildApplyCorrectionsRequest";
 
 const POLL_INTERVAL_MS = 1500;
 
@@ -29,6 +31,10 @@ type AppContextValue = {
   setCorrectionDecision: (issueIndex: number, decision: CorrectionDecision) => void;
   clearCorrectionDecision: (issueIndex: number) => void;
   resetCorrectionDecisions: () => void;
+  isApplyingCorrections: boolean;
+  applyCorrectionsError: string | null;
+  lastApplyCorrectionsResult: ApplyCorrectionsResponse | null;
+  handleApplyCorrections: () => Promise<void>;
 };
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -43,6 +49,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
   );
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [isApplyingCorrections, setIsApplyingCorrections] = useState(false);
+  const [applyCorrectionsError, setApplyCorrectionsError] = useState<string | null>(null);
+  const [lastApplyCorrectionsResult, setLastApplyCorrectionsResult] =
+    useState<ApplyCorrectionsResponse | null>(null);
 
   async function handleUploadFile(file: File) {
     setError(null);
@@ -62,6 +72,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
       setValidationResult(null);
       setCorrectionDecisions({});
       setValidationError(null);
+      setApplyCorrectionsError(null);
+      setLastApplyCorrectionsResult(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Upload failed");
     } finally {
@@ -81,6 +93,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setValidationError(null);
     setValidationResult(null);
     setCorrectionDecisions({});
+    setApplyCorrectionsError(null);
+    setLastApplyCorrectionsResult(null);
     setIsValidating(true);
     try {
       const startRes = await fetch("/api/v1/validate/async", {
@@ -125,6 +139,40 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setValidationResult(null);
     setCorrectionDecisions({});
     setValidationError(null);
+    setApplyCorrectionsError(null);
+    setLastApplyCorrectionsResult(null);
+  }
+
+  async function handleApplyCorrections() {
+    if (!currentDataset?.dataset_id || !validationResult) return;
+    const corrections = buildApplyCorrectionsActions(validationResult, correctionDecisions);
+    if (corrections.length === 0) return;
+
+    setApplyCorrectionsError(null);
+    setLastApplyCorrectionsResult(null);
+    setIsApplyingCorrections(true);
+    try {
+      const res = await fetch("/api/v1/corrections/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dataset_id: currentDataset.dataset_id,
+          corrections,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const detail =
+          typeof data.detail === "string" ? data.detail : data.detail?.detail ?? res.statusText;
+        throw new Error(detail);
+      }
+      const data = (await res.json()) as ApplyCorrectionsResponse;
+      setLastApplyCorrectionsResult(data);
+    } catch (e) {
+      setApplyCorrectionsError(e instanceof Error ? e.message : "Apply corrections failed");
+    } finally {
+      setIsApplyingCorrections(false);
+    }
   }
 
   function setCorrectionDecision(issueIndex: number, decision: CorrectionDecision) {
@@ -162,6 +210,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
         setCorrectionDecision,
         clearCorrectionDecision,
         resetCorrectionDecisions,
+        isApplyingCorrections,
+        applyCorrectionsError,
+        lastApplyCorrectionsResult,
+        handleApplyCorrections,
       }}
     >
       {children}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -32,6 +32,13 @@ export type CorrectionSuggestion = {
 /** User choice for a suggested correction (issue #103); persisted until apply or reset. */
 export type CorrectionDecision = "approve" | "reject" | "custom";
 
+/** POST /corrections/apply response (aligned with backend ApplyCorrectionsResponse). */
+export type ApplyCorrectionsResponse = {
+  applied: number;
+  skipped: number;
+  download_url?: string | null;
+};
+
 /** Async validation job status (GET /validate/jobs/{job_id}). */
 export type ValidationJobStatus = {
   job_id: string;

--- a/frontend/src/utils/buildApplyCorrectionsRequest.ts
+++ b/frontend/src/utils/buildApplyCorrectionsRequest.ts
@@ -1,0 +1,33 @@
+import type { CorrectionDecision, ValidationResult } from "../types/api";
+
+/** API shape for POST /corrections/apply (backend CorrectionAction). */
+export type CorrectionActionPayload = {
+  issue_index: number;
+  action: "approve" | "reject";
+};
+
+/**
+ * Build the corrections list from UI state. Only includes indices that have a
+ * matching CorrectionSuggestion. Maps "custom" to approve (same suggestion until
+ * override payload exists; see issue #106).
+ */
+export function buildApplyCorrectionsActions(
+  validationResult: ValidationResult,
+  correctionDecisions: Record<number, CorrectionDecision>,
+): CorrectionActionPayload[] {
+  const withSuggestion = new Set(
+    (validationResult.corrections ?? []).map((c) => c.issue_index),
+  );
+  const list: CorrectionActionPayload[] = [];
+  for (const [idxStr, decision] of Object.entries(correctionDecisions)) {
+    const issueIndex = Number(idxStr);
+    if (Number.isNaN(issueIndex) || !withSuggestion.has(issueIndex)) continue;
+    if (decision === "reject") {
+      list.push({ issue_index: issueIndex, action: "reject" });
+    } else {
+      list.push({ issue_index: issueIndex, action: "approve" });
+    }
+  }
+  list.sort((a, b) => a.issue_index - b.issue_index);
+  return list;
+}


### PR DESCRIPTION
## Summary

This pull request implements **issue #104**: wire the app to **`POST /api/v1/corrections/apply`** with a request body built from per-issue user decisions (**#103** Approve / Reject / Custom), handle success and errors, and guard the apply action when there is nothing to send or no dataset.

Because the API route did not exist yet, this PR adds a minimal **FastAPI** implementation plus **pytest** coverage. Full geometry mutation and a dedicated cleaned export are left for follow-up work (see **#105** / README).

## Backend

- **`ApplyCorrectionsResponse`** (`applied`, `skipped`, optional `download_url`) in `api/models.py`.
- **`POST /api/v1/corrections/apply`** in `api/routes.py`:
  - **400** if `corrections` is empty.
  - **404** if the dataset has no primary vector file (same discovery pattern as validation).
  - Computes **applied** (count of `approve`) and **skipped** (count of `reject`); if the same `issue_index` appears more than once, **the last action wins**.
  - Sets **`download_url`** to `/api/v1/datasets/{dataset_id}/geojson` as an interim link until a real cleaned export exists.

## Frontend

- **`ApplyCorrectionsResponse`** type in `frontend/src/types/api.ts`.
- **`buildApplyCorrectionsActions`** (`frontend/src/utils/buildApplyCorrectionsRequest.ts`): builds the API `corrections` array from `validationResult.corrections` and `correctionDecisions`; only includes indices that have a matching suggestion; maps **`custom` → `approve`** until override payloads exist (**#106**).
- **`AppContext`**: `handleApplyCorrections`, `isApplyingCorrections`, `applyCorrectionsError`, `lastApplyCorrectionsResult`; clears apply-related state on upload, new validation, and `clearValidation()`.
- **`DashboardPage`**: **Apply corrections** button (disabled when no dataset, no validation result, no applicable decisions, or while validating/applying), loading and error messaging, and a short success summary with optional download link.

## Testing

- `pytest tests/test_api.py -v` — all tests pass, including new cases for empty body, success counts, duplicate `issue_index`, and missing dataset.

## Related issues

- Closes #104
- Builds on #103 (correction choices in UI)
- Part of #11 (Interactive correction workflow)
- **#105** may refine applied/skipped UX and a real cleaned-dataset download.
- **#106** may add custom overrides instead of mapping `custom` to `approve`.