### PR TITLE
feat(dashboard): apply results panel, export note, and GeoJSON download (#105)

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -68,13 +68,17 @@ class ApplyCorrectionsRequest(BaseModel):
 
 
 class ApplyCorrectionsResponse(BaseModel):
-    """Response from POST /corrections/apply (README + issue #104)."""
+    """Response from POST /corrections/apply (README + issue #104, UX #105)."""
 
     applied: int = Field(..., ge=0, description="Number of corrections approved for application")
     skipped: int = Field(..., ge=0, description="Number of corrections rejected (skipped)")
     download_url: Optional[str] = Field(
         None,
         description="Optional URL to download cleaned export when implemented; may point at dataset GeoJSON meanwhile",
+    )
+    export_note: Optional[str] = Field(
+        None,
+        description="Short human-readable note about what the download contains (issue #105)",
     )
 
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -352,5 +352,14 @@ async def apply_corrections(body: ApplyCorrectionsRequest):
     skipped = sum(1 for a in by_index.values() if a == "reject")
 
     download_url = f"/api/v1/datasets/{body.dataset_id}/geojson"
+    export_note = (
+        "This link downloads the dataset’s current GeoJSON as stored on the server. "
+        "A dedicated cleaned-export file (e.g. ZIP) may replace it when the export pipeline is implemented."
+    )
 
-    return ApplyCorrectionsResponse(applied=applied, skipped=skipped, download_url=download_url)
+    return ApplyCorrectionsResponse(
+        applied=applied,
+        skipped=skipped,
+        download_url=download_url,
+        export_note=export_note,
+    )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -60,6 +60,7 @@ def test_apply_corrections_success(client, tmp_path, monkeypatch):
     assert data["applied"] == 1
     assert data["skipped"] == 1
     assert dataset_id in (data.get("download_url") or "")
+    assert data.get("export_note")
 
 
 def test_apply_corrections_duplicate_issue_index_last_wins(client, tmp_path, monkeypatch):

--- a/frontend/src/components/Dashboard/ApplyResultsPanel.tsx
+++ b/frontend/src/components/Dashboard/ApplyResultsPanel.tsx
@@ -1,0 +1,72 @@
+import { CalciteButton, CalciteNotice, CalcitePanel } from "@esri/calcite-components-react";
+
+import type { ApplyCorrectionsResponse } from "../../types/api";
+import { summarizeApplyResults } from "../../utils/applyResultsSummary";
+
+export type ApplyResultsPanelProps = {
+  result: ApplyCorrectionsResponse;
+  onDismiss: () => void;
+};
+
+export function ApplyResultsPanel({ result, onDismiss }: ApplyResultsPanelProps) {
+  const { applied, skipped, download_url: downloadUrl, export_note: exportNote } = result;
+  const total = applied + skipped;
+
+  return (
+    <CalcitePanel className="apply-results-panel" heading="Correction apply results">
+      <p className="apply-results__intro">
+        Counts from the last successful request to apply your choices.
+      </p>
+      <div className="apply-results__counts" role="group" aria-label="Apply counts">
+        <div className="apply-results__stat">
+          <span className="apply-results__stat-label">Approved</span>
+          <span className="apply-results__stat-value">{applied}</span>
+        </div>
+        <div className="apply-results__stat">
+          <span className="apply-results__stat-label">Skipped</span>
+          <span className="apply-results__stat-value">{skipped}</span>
+        </div>
+        <div className="apply-results__stat">
+          <span className="apply-results__stat-label">Total</span>
+          <span className="apply-results__stat-value">{total}</span>
+        </div>
+      </div>
+
+      <p className="apply-results__summary">{summarizeApplyResults(applied, skipped)}</p>
+
+      {exportNote ? <p className="apply-results__note">{exportNote}</p> : null}
+
+      {downloadUrl ? (
+        <div className="apply-results__download">
+          <CalciteButton
+            href={downloadUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+            download
+            kind="brand"
+            label="Download dataset file (opens in a new tab)"
+          >
+            Download dataset (GeoJSON)
+          </CalciteButton>
+          <p className="apply-results__download-hint">
+            Opens the current layer file from the server. Use &quot;Save as&quot; in the browser if the file opens
+            inline instead of downloading.
+          </p>
+        </div>
+      ) : (
+        <CalciteNotice open kind="warning" icon scale="s" width="full">
+          <div slot="title">No download link</div>
+          <div slot="message">
+            The server did not return an export URL. A cleaned-dataset download may be added in a later release.
+          </div>
+        </CalciteNotice>
+      )}
+
+      <div className="apply-results__footer">
+        <CalciteButton appearance="outline" kind="neutral" onClick={onDismiss}>
+          Dismiss results
+        </CalciteButton>
+      </div>
+    </CalcitePanel>
+  );
+}

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { MapViewer } from "../Map/MapViewer";
 import { SummaryStats } from "./SummaryStats";
 import { IssuesPanel } from "./IssuesPanel";
 import { DetailView } from "./DetailView";
+import { ApplyResultsPanel } from "./ApplyResultsPanel";
 import { useApp } from "../../context/AppContext";
 import { buildApplyCorrectionsActions } from "../../utils/buildApplyCorrectionsRequest";
 
@@ -21,6 +22,7 @@ export function DashboardPage() {
     applyCorrectionsError,
     lastApplyCorrectionsResult,
     handleApplyCorrections,
+    dismissLastApplyResult,
   } = useApp();
   const [selectedIssueIndex, setSelectedIssueIndex] = useState<number | null>(null);
 
@@ -92,18 +94,10 @@ export function DashboardPage() {
                 {applyCorrectionsError}
               </p>
             )}
-            {lastApplyCorrectionsResult && (
-              <p className="status-message status-message--success" role="status">
-                Applied {lastApplyCorrectionsResult.applied}, skipped {lastApplyCorrectionsResult.skipped}.
-                {lastApplyCorrectionsResult.download_url ? (
-                  <>
-                    {" "}
-                    <a href={lastApplyCorrectionsResult.download_url}>Dataset download</a>
-                  </>
-                ) : null}
-              </p>
-            )}
           </div>
+          {lastApplyCorrectionsResult ? (
+            <ApplyResultsPanel result={lastApplyCorrectionsResult} onDismiss={dismissLastApplyResult} />
+          ) : null}
           <div className="dashboard-grid">
             <CalcitePanel heading={currentDataset.filename} className="dashboard-panel dashboard-panel--map">
               <MapViewer

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -35,6 +35,7 @@ type AppContextValue = {
   applyCorrectionsError: string | null;
   lastApplyCorrectionsResult: ApplyCorrectionsResponse | null;
   handleApplyCorrections: () => Promise<void>;
+  dismissLastApplyResult: () => void;
 };
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -191,6 +192,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setCorrectionDecisions({});
   }
 
+  function dismissLastApplyResult() {
+    setLastApplyCorrectionsResult(null);
+  }
+
   return (
     <AppContext.Provider
       value={{
@@ -214,6 +219,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         applyCorrectionsError,
         lastApplyCorrectionsResult,
         handleApplyCorrections,
+        dismissLastApplyResult,
       }}
     >
       {children}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -203,6 +203,68 @@ calcite-shell .app-main {
   flex-shrink: 0;
 }
 
+.apply-results-panel {
+  margin-bottom: 1rem;
+}
+
+.apply-results__intro {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.apply-results__counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.apply-results__stat {
+  min-width: 5rem;
+}
+
+.apply-results__stat-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #6a6a6a;
+}
+
+.apply-results__stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.apply-results__summary {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.apply-results__note {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: #555;
+  line-height: 1.4;
+}
+
+.apply-results__download {
+  margin-bottom: 1rem;
+}
+
+.apply-results__download-hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: #6a6a6a;
+}
+
+.apply-results__footer {
+  margin-top: 0.5rem;
+}
+
 .upload-label {
   display: block;
   margin-bottom: 0.75rem;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -37,6 +37,8 @@ export type ApplyCorrectionsResponse = {
   applied: number;
   skipped: number;
   download_url?: string | null;
+  /** Server hint about what the download is (issue #105). */
+  export_note?: string | null;
 };
 
 /** Async validation job status (GET /validate/jobs/{job_id}). */

--- a/frontend/src/utils/applyResultsSummary.ts
+++ b/frontend/src/utils/applyResultsSummary.ts
@@ -1,0 +1,16 @@
+/**
+ * Human-readable summary for apply-corrections counts (issue #105).
+ */
+export function summarizeApplyResults(applied: number, skipped: number): string {
+  const total = applied + skipped;
+  if (total === 0) {
+    return "No correction decisions were returned in this response. Try applying again after selecting Approve or Reject for at least one suggested fix.";
+  }
+  if (applied === 0 && skipped > 0) {
+    return "All submitted corrections were skipped (rejected). Nothing was approved for application in this run.";
+  }
+  if (applied > 0 && skipped === 0) {
+    return "Every submitted correction was approved. The server recorded them for application.";
+  }
+  return `Mixed outcome: ${applied} approved for application and ${skipped} skipped (rejected).`;
+}


### PR DESCRIPTION
## Summary

Implements clearer feedback after users apply correction decisions: a dedicated **apply results** panel on the dashboard, human-readable outcome copy for empty / partial / all-skipped cases, and an explicit **dataset download** path with context about what the file represents today.

This addresses the dashboard UX gap described in **#105** (child of **#11** — export / cleaned dataset experience).

## What changed

### Backend

- Extended `ApplyCorrectionsResponse` with optional `export_note` so clients can show consistent messaging next to the download action.
- `POST /api/v1/corrections/apply` now returns `export_note` explaining that the link is the dataset’s **current GeoJSON on the server**, and that a dedicated cleaned export (e.g. ZIP) may replace it when the export pipeline exists.
- API test for a successful apply now asserts `export_note` is present so the contract does not regress silently.

### Frontend

- New **`ApplyResultsPanel`** (Calcite): approved / skipped / total counts, summary line from **`summarizeApplyResults`**, optional `export_note`, primary **Download dataset (GeoJSON)** button when `download_url` is set (new tab + `download` attribute + short “Save as” hint), warning notice when no URL, and **Dismiss** wired through app context.
- **`DashboardPage`** shows the panel after a successful apply instead of a single-line toast-style message.
- Scoped styles under `.apply-results-*` in `index.css`.
- Types updated for `ApplyCorrectionsResponse`.

## How to verify

1. Upload or select a dataset, run validation, open corrections, submit **Apply** with a mix of approve/reject.
2. Confirm the panel appears with correct counts and summary; download opens/saves as expected; dismiss clears the panel.
3. Backend: `python -m pytest tests/test_api.py -v`
4. Frontend: `npm run build` (from `frontend/`)

## Related issues

- Closes #105
- Related to #11 (parent / export roadmap)
