### PR TITLE
feat(#106): In-UI manual edit before apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,8 @@ Response: 200 OK
 
 **Suggestion schema (issue #86):** Validation results may include a `corrections` list. Each item is a **CorrectionSuggestion** (`api/models.py`): `method` (e.g. `buffer(0)`, `rename field`), `confidence` (0–1), `explanation` (natural-language), and `issue_index` (index into the `issues` list). The Recommendation Agent populates `state["corrections"]` in this shape. The apply-corrections API accepts **CorrectionAction** entries (`issue_index`, `action`: `approve` | `reject`) so the client can approve or reject each suggestion by issue index.
 
+**Custom manual edits (issue #106):** In the dashboard, choose **Custom** on a suggested fix to edit geometry as **WKT** and/or attributes as a **JSON object**, then apply. Optional fields on each approved action: `feature_id`, `geometry_wkt`, `attributes`. The server writes those overrides into the dataset GeoJSON when present. **Limitations:** there is no interactive map vertex editing; approve without overrides still does not run automated suggestion methods (e.g. `buffer(0)`); shapefile-only uploads are not mutated in place unless a GeoJSON sidecar exists.
+
 [Full API documentation](docs/api/README.md)
 
 ---

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,5 +1,5 @@
 """Pydantic schemas for API request/response."""
-from typing import Any, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -55,6 +55,18 @@ class CorrectionAction(BaseModel):
 
     issue_index: int = Field(..., ge=0, description="Index into the issues list")
     action: Literal["approve", "reject"] = Field(..., description="Whether to apply or skip this correction")
+    feature_id: Optional[Any] = Field(
+        None,
+        description="Feature to update when geometry_wkt or attributes overrides are supplied (issue #106)",
+    )
+    geometry_wkt: Optional[str] = Field(
+        None,
+        description="Optional Well-Known Text geometry to apply for this feature when action is approve",
+    )
+    attributes: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Optional attribute key/value overrides for this feature when action is approve",
+    )
 
 
 class ApplyCorrectionsRequest(BaseModel):

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -8,6 +8,7 @@ from fastapi.responses import FileResponse
 from api.models import (
     ApplyCorrectionsRequest,
     ApplyCorrectionsResponse,
+    CorrectionAction,
     ErrorCode,
     ErrorResponse,
     UploadResponse,
@@ -23,6 +24,7 @@ from services.file_handler import (
     get_upload_path,
     save_upload,
 )
+from services.correction_applier import apply_correction_overrides
 from services.geojson_parser import parse_geojson_metadata
 from services.shapefile_parser import parse_shapefile_metadata
 from agents.orchestrator import empty_state, validation_graph
@@ -344,18 +346,34 @@ async def apply_corrections(body: ApplyCorrectionsRequest):
         )
 
     # Last entry wins if the same issue_index appears more than once.
-    by_index: dict[int, str] = {}
+    by_index: dict[int, CorrectionAction] = {}
     for item in body.corrections:
-        by_index[item.issue_index] = item.action
+        by_index[item.issue_index] = item
 
-    applied = sum(1 for a in by_index.values() if a == "approve")
-    skipped = sum(1 for a in by_index.values() if a == "reject")
+    applied = sum(1 for a in by_index.values() if a.action == "approve")
+    skipped = sum(1 for a in by_index.values() if a.action == "reject")
+
+    correction_payloads = [item.model_dump() for item in by_index.values()]
+    try:
+        mutated = apply_correction_overrides(path, correction_payloads)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"detail": str(exc), "code": "INVALID_OVERRIDE"},
+        ) from exc
 
     download_url = f"/api/v1/datasets/{body.dataset_id}/geojson"
-    export_note = (
-        "This link downloads the dataset’s current GeoJSON as stored on the server. "
-        "A dedicated cleaned-export file (e.g. ZIP) may replace it when the export pipeline is implemented."
-    )
+    if mutated:
+        export_note = (
+            f"Applied manual overrides to {mutated} feature(s) in the dataset GeoJSON. "
+            "Download reflects those edits; map editing in the UI is not supported (WKT/attributes only)."
+        )
+    else:
+        export_note = (
+            "This link downloads the dataset’s current GeoJSON as stored on the server. "
+            "Approve decisions without custom overrides do not change geometry yet. "
+            "A dedicated cleaned-export file (e.g. ZIP) may replace this when the export pipeline is extended."
+        )
 
     return ApplyCorrectionsResponse(
         applied=applied,

--- a/backend/services/correction_applier.py
+++ b/backend/services/correction_applier.py
@@ -1,0 +1,78 @@
+"""Apply user-supplied geometry/attribute overrides to dataset GeoJSON (issue #106)."""
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import geopandas as gpd
+from shapely import wkt as shapely_wkt
+
+
+def _resolve_feature_index(gdf: gpd.GeoDataFrame, feature_id: Any) -> Optional[Any]:
+    """Return GeoDataFrame index for feature_id (matches validation feature_id rules)."""
+    if "id" in gdf.columns:
+        matches = gdf[gdf["id"].astype(str) == str(feature_id)]
+        if not matches.empty:
+            return matches.index[0]
+
+    for idx in gdf.index:
+        if idx == feature_id or str(idx) == str(feature_id):
+            return idx
+        try:
+            if int(idx) == int(feature_id):
+                return idx
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def apply_correction_overrides(
+    vector_path: Path,
+    corrections: List[Dict[str, Any]],
+) -> int:
+    """
+    Apply approved corrections that include geometry_wkt and/or attributes.
+
+    Writes updated GeoJSON back to vector_path. Returns the number of features mutated.
+    """
+    overrides = [
+        c
+        for c in corrections
+        if c.get("action") == "approve" and (c.get("geometry_wkt") or c.get("attributes"))
+    ]
+    if not overrides:
+        return 0
+
+    gdf = gpd.read_file(vector_path)
+    if gdf.empty:
+        return 0
+
+    mutated = 0
+    for item in overrides:
+        feature_id = item.get("feature_id")
+        if feature_id is None:
+            continue
+        row_idx = _resolve_feature_index(gdf, feature_id)
+        if row_idx is None:
+            continue
+
+        changed = False
+        wkt_text = item.get("geometry_wkt")
+        if wkt_text and str(wkt_text).strip():
+            try:
+                geom = shapely_wkt.loads(str(wkt_text).strip())
+            except Exception as exc:
+                raise ValueError(f"Invalid WKT for feature {feature_id}: {exc}") from exc
+            gdf.at[row_idx, gdf.geometry.name] = geom
+            changed = True
+
+        attrs = item.get("attributes")
+        if attrs:
+            for key, value in attrs.items():
+                gdf.at[row_idx, key] = value
+            changed = True
+
+        if changed:
+            mutated += 1
+
+    if mutated:
+        gdf.to_file(vector_path, driver="GeoJSON")
+    return mutated

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -87,6 +87,80 @@ def test_apply_corrections_duplicate_issue_index_last_wins(client, tmp_path, mon
     assert data["skipped"] == 1
 
 
+def test_apply_corrections_with_geometry_override(client, tmp_path, monkeypatch):
+    """POST /corrections/apply applies geometry_wkt to GeoJSON when provided."""
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    dataset_id = "ds-override"
+    dest = tmp_path / dataset_id
+    dest.mkdir()
+    geojson_path = dest / "data.geojson"
+    gdf = gpd.GeoDataFrame(
+        {"id": [1], "name": ["A"]},
+        geometry=[Point(-122.4, 37.77)],
+        crs="EPSG:4326",
+    )
+    gdf.to_file(geojson_path, driver="GeoJSON")
+
+    response = client.post(
+        "/api/v1/corrections/apply",
+        json={
+            "dataset_id": dataset_id,
+            "corrections": [
+                {
+                    "issue_index": 0,
+                    "action": "approve",
+                    "feature_id": 1,
+                    "geometry_wkt": "POINT (-122.5 37.8)",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] == 1
+    assert "manual overrides" in (data.get("export_note") or "").lower()
+
+    updated = gpd.read_file(geojson_path)
+    assert abs(updated.geometry.iloc[0].x + 122.5) < 1e-6
+
+
+def test_apply_corrections_invalid_wkt_returns_400(client, tmp_path, monkeypatch):
+    """Invalid geometry_wkt returns 400 with INVALID_OVERRIDE."""
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))
+    dataset_id = "ds-bad-wkt"
+    dest = tmp_path / dataset_id
+    dest.mkdir()
+    geojson_path = dest / "data.geojson"
+    gpd.GeoDataFrame({"id": [0]}, geometry=[Point(0, 0)], crs="EPSG:4326").to_file(
+        geojson_path, driver="GeoJSON"
+    )
+
+    response = client.post(
+        "/api/v1/corrections/apply",
+        json={
+            "dataset_id": dataset_id,
+            "corrections": [
+                {
+                    "issue_index": 0,
+                    "action": "approve",
+                    "feature_id": 0,
+                    "geometry_wkt": "NOT VALID",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json().get("detail", {}).get("code") == "INVALID_OVERRIDE"
+
+
 def test_apply_corrections_dataset_not_found(client, tmp_path, monkeypatch):
     """POST /corrections/apply returns 404 when dataset has no vector file."""
     monkeypatch.setattr("core.config.settings.UPLOAD_DIR", str(tmp_path))

--- a/backend/tests/test_correction_applier.py
+++ b/backend/tests/test_correction_applier.py
@@ -1,0 +1,74 @@
+"""Tests for correction_applier service (issue #106)."""
+import json
+
+import geopandas as gpd
+from shapely.geometry import Point
+
+from services.correction_applier import apply_correction_overrides
+
+
+def _write_points_geojson(path, coords):
+    gdf = gpd.GeoDataFrame(
+        {"id": list(range(len(coords))), "name": [f"P{i}" for i in range(len(coords))]},
+        geometry=[Point(x, y) for x, y in coords],
+        crs="EPSG:4326",
+    )
+    gdf.to_file(path, driver="GeoJSON")
+
+
+def test_apply_geometry_wkt_updates_feature(tmp_path):
+    geojson_path = tmp_path / "data.geojson"
+    _write_points_geojson(geojson_path, [(-122.4, 37.77)])
+
+    mutated = apply_correction_overrides(
+        geojson_path,
+        [
+            {
+                "action": "approve",
+                "feature_id": 0,
+                "geometry_wkt": "POINT (-122.5 37.8)",
+            }
+        ],
+    )
+    assert mutated == 1
+
+    gdf = gpd.read_file(geojson_path)
+    pt = gdf.geometry.iloc[0]
+    assert abs(pt.x + 122.5) < 1e-6
+    assert abs(pt.y - 37.8) < 1e-6
+
+
+def test_apply_attributes_updates_properties(tmp_path):
+    geojson_path = tmp_path / "data.geojson"
+    _write_points_geojson(geojson_path, [(-122.4, 37.77)])
+
+    mutated = apply_correction_overrides(
+        geojson_path,
+        [
+            {
+                "action": "approve",
+                "feature_id": 0,
+                "attributes": {"name": "Updated", "score": 99},
+            }
+        ],
+    )
+    assert mutated == 1
+
+    raw = json.loads(geojson_path.read_text(encoding="utf-8"))
+    props = raw["features"][0]["properties"]
+    assert props["name"] == "Updated"
+    assert props["score"] == 99
+
+
+def test_invalid_wkt_raises(tmp_path):
+    geojson_path = tmp_path / "data.geojson"
+    _write_points_geojson(geojson_path, [(-122.4, 37.77)])
+
+    try:
+        apply_correction_overrides(
+            geojson_path,
+            [{"action": "approve", "feature_id": 0, "geometry_wkt": "NOT VALID WKT"}],
+        )
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "Invalid WKT" in str(exc)

--- a/frontend/src/components/Dashboard/CustomCorrectionEditor.tsx
+++ b/frontend/src/components/Dashboard/CustomCorrectionEditor.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+import { CalciteButton, CalciteLabel, CalciteTextArea } from "@esri/calcite-components-react";
+
+import type { CorrectionOverride, GeometryIssue } from "../../types/api";
+import {
+  findFeatureInCollection,
+  type GeoJsonFeatureCollection,
+} from "../../utils/findFeatureInCollection";
+
+export type CustomCorrectionEditorProps = {
+  datasetId: string;
+  issue: GeometryIssue;
+  savedOverride: CorrectionOverride | undefined;
+  onSave: (override: CorrectionOverride) => void;
+  onClear: () => void;
+  disabled?: boolean;
+};
+
+function isGeometryIssueType(type: string): boolean {
+  return !type.startsWith("attribute_") && !type.startsWith("topology_");
+}
+
+export function CustomCorrectionEditor({
+  datasetId,
+  issue,
+  savedOverride,
+  onSave,
+  onClear,
+  disabled = false,
+}: CustomCorrectionEditorProps) {
+  const [geometryWkt, setGeometryWkt] = useState(savedOverride?.geometry_wkt ?? "");
+  const [attributesJson, setAttributesJson] = useState("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const showGeometry = isGeometryIssueType(issue.type || "");
+
+  useEffect(() => {
+    setGeometryWkt(savedOverride?.geometry_wkt ?? "");
+    if (savedOverride?.attributes) {
+      setAttributesJson(JSON.stringify(savedOverride.attributes, null, 2));
+    }
+  }, [savedOverride]);
+
+  useEffect(() => {
+    if (savedOverride?.attributes || issue.feature_id === undefined || issue.feature_id === null) {
+      return;
+    }
+    let cancelled = false;
+    setLoadError(null);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/v1/datasets/${datasetId}/geojson`);
+        if (!res.ok) return;
+        const collection = (await res.json()) as GeoJsonFeatureCollection;
+        const feature = findFeatureInCollection(collection, issue.feature_id);
+        if (cancelled || !feature?.properties) return;
+        const { geometry: _geom, ...rest } = feature.properties as Record<string, unknown>;
+        void _geom;
+        if (Object.keys(rest).length > 0) {
+          setAttributesJson(JSON.stringify(rest, null, 2));
+        }
+      } catch {
+        if (!cancelled) setLoadError("Could not load current feature attributes.");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, issue.feature_id, savedOverride?.attributes]);
+
+  function handleSave() {
+    setParseError(null);
+    let attributes: Record<string, unknown> | undefined;
+    const trimmedAttrs = attributesJson.trim();
+    if (trimmedAttrs) {
+      try {
+        const parsed = JSON.parse(trimmedAttrs) as unknown;
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          setParseError("Attributes must be a JSON object (e.g. {\"name\": \"value\"}).");
+          return;
+        }
+        attributes = parsed as Record<string, unknown>;
+      } catch {
+        setParseError("Attributes must be valid JSON.");
+        return;
+      }
+    }
+
+    const trimmedWkt = geometryWkt.trim();
+    if (!trimmedWkt && !attributes) {
+      setParseError("Enter geometry WKT and/or attribute JSON before saving.");
+      return;
+    }
+
+    onSave({
+      feature_id: issue.feature_id,
+      ...(trimmedWkt ? { geometry_wkt: trimmedWkt } : {}),
+      ...(attributes ? { attributes } : {}),
+    });
+  }
+
+  return (
+    <div className="custom-correction-editor">
+      <p className="custom-correction-editor__intro">
+        Edit values below, then save. Overrides are sent when you apply corrections. There is no
+        interactive map editor — use WKT for geometry and JSON for attributes.
+      </p>
+      {loadError && <p className="custom-correction-editor__error">{loadError}</p>}
+      {showGeometry && (
+        <CalciteLabel>
+          Geometry (WKT)
+          <CalciteTextArea
+            value={geometryWkt}
+            placeholder='e.g. POINT (-122.42 37.78) or POLYGON ((...))'
+            rows={4}
+            disabled={disabled}
+            onCalciteTextAreaInput={(event) => {
+              setGeometryWkt((event.target as HTMLCalciteTextAreaElement).value ?? "");
+            }}
+          />
+        </CalciteLabel>
+      )}
+      <CalciteLabel>
+        Attributes (JSON object)
+        <CalciteTextArea
+          value={attributesJson}
+          placeholder='{"name": "Corrected name"}'
+          rows={5}
+          disabled={disabled}
+          onCalciteTextAreaInput={(event) => {
+            setAttributesJson((event.target as HTMLCalciteTextAreaElement).value ?? "");
+          }}
+        />
+      </CalciteLabel>
+      {parseError && <p className="custom-correction-editor__error">{parseError}</p>}
+      {savedOverride && (
+        <p className="custom-correction-editor__saved" role="status">
+          Custom fix saved for this issue.
+        </p>
+      )}
+      <div className="custom-correction-editor__actions">
+        <CalciteButton kind="brand" onClick={handleSave} disabled={disabled}>
+          Save custom fix
+        </CalciteButton>
+        {savedOverride && (
+          <CalciteButton appearance="outline" kind="neutral" onClick={onClear} disabled={disabled}>
+            Clear saved fix
+          </CalciteButton>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -13,7 +13,10 @@ import { IssuesPanel } from "./IssuesPanel";
 import { DetailView } from "./DetailView";
 import { ApplyResultsPanel } from "./ApplyResultsPanel";
 import { useApp } from "../../context/AppContext";
-import { buildApplyCorrectionsActions } from "../../utils/buildApplyCorrectionsRequest";
+import {
+  buildApplyCorrectionsActions,
+  hasPendingCustomCorrections,
+} from "../../utils/buildApplyCorrectionsRequest";
 
 export function DashboardPage() {
   const {
@@ -21,6 +24,7 @@ export function DashboardPage() {
     validationIssues,
     validationResult,
     correctionDecisions,
+    correctionOverrides,
     isValidating,
     validationError,
     handleValidate,
@@ -40,11 +44,22 @@ export function DashboardPage() {
 
   const applyActionsCount = useMemo(() => {
     if (!validationResult) return 0;
-    return buildApplyCorrectionsActions(validationResult, correctionDecisions).length;
-  }, [validationResult, correctionDecisions]);
+    return buildApplyCorrectionsActions(
+      validationResult,
+      correctionDecisions,
+      correctionOverrides,
+    ).length;
+  }, [validationResult, correctionDecisions, correctionOverrides]);
+
+  const pendingCustomEdits = useMemo(
+    () => hasPendingCustomCorrections(correctionDecisions, correctionOverrides),
+    [correctionDecisions, correctionOverrides],
+  );
 
   const canApplyCorrections =
-    Boolean(currentDataset?.dataset_id && validationResult && applyActionsCount > 0);
+    Boolean(
+      currentDataset?.dataset_id && validationResult && applyActionsCount > 0 && !pendingCustomEdits,
+    );
 
   const validateWillClearFeedback =
     Object.keys(correctionDecisions).length > 0 || lastApplyCorrectionsResult !== null;
@@ -124,10 +139,15 @@ export function DashboardPage() {
                 <span>Validation in progress. Issues and map will update when complete.</span>
               </div>
             )}
+            {pendingCustomEdits && (
+              <p className="dashboard-validation-status" role="status">
+                Save custom fixes for all Custom issues before applying corrections.
+              </p>
+            )}
             {isApplyingCorrections && (
               <div className="dashboard-validation-status" role="status" aria-live="polite">
                 <CalciteLoader scale="s" />
-                <span>Sending your approve/reject choices to the API…</span>
+                <span>Sending your correction choices to the API…</span>
               </div>
             )}
             {validationError && (

--- a/frontend/src/components/Dashboard/DetailView.tsx
+++ b/frontend/src/components/Dashboard/DetailView.tsx
@@ -3,6 +3,7 @@ import { CalciteButton, CalciteDialog } from "@esri/calcite-components-react";
 
 import { useApp } from "../../context/AppContext";
 import type { CorrectionSuggestion, GeometryIssue } from "../../types/api";
+import { CustomCorrectionEditor } from "./CustomCorrectionEditor";
 
 export type DetailViewProps = {
   selectedIssueIndex: number | null;
@@ -12,8 +13,12 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
   const [resetAllConfirmOpen, setResetAllConfirmOpen] = useState(false);
   const {
     validationResult,
+    currentDataset,
     correctionDecisions,
+    correctionOverrides,
     setCorrectionDecision,
+    setCorrectionOverride,
+    clearCorrectionOverride,
     clearCorrectionDecision,
     resetCorrectionDecisions,
     isApplyingCorrections,
@@ -148,10 +153,22 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
                   Custom
                 </CalciteButton>
               </div>
-              <p className="correction-actions__hint correction-actions__hint--custom">
-                <strong>Custom:</strong> you will supply or adjust the fix before applying corrections
-                (manual editing UI can follow in a later task).
-              </p>
+              {decision === "custom" && currentDataset?.dataset_id && (
+                <CustomCorrectionEditor
+                  datasetId={currentDataset.dataset_id}
+                  issue={issue}
+                  savedOverride={correctionOverrides[issueIndex]}
+                  onSave={(override) => setCorrectionOverride(issueIndex, override)}
+                  onClear={() => clearCorrectionOverride(issueIndex)}
+                  disabled={isApplyingCorrections}
+                />
+              )}
+              {decision === "custom" && !correctionOverrides[issueIndex] && (
+                <p className="correction-actions__hint correction-actions__hint--custom">
+                  <strong>Custom:</strong> save your geometry WKT and/or attribute JSON before applying
+                  corrections.
+                </p>
+              )}
               <div className="correction-actions__footer">
                 <button
                   type="button"

--- a/frontend/src/components/Dashboard/IssuesPanel.tsx
+++ b/frontend/src/components/Dashboard/IssuesPanel.tsx
@@ -48,7 +48,12 @@ function decisionShortLabel(d: CorrectionDecision): string {
 }
 
 export function IssuesPanel({ issues, onSelectIssueIndex }: IssuesPanelProps) {
-  const { validationResult, correctionDecisions } = useApp();
+  const { validationResult, correctionDecisions, correctionOverrides } = useApp();
+
+  const indicesWithCorrection = useMemo(
+    () => correctionIndicesFromIssues(issues, validationResult?.corrections),
+    [issues, validationResult?.corrections],
+  );
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
   const [featureFilter, setFeatureFilter] = useState<string>("");
@@ -168,13 +173,21 @@ export function IssuesPanel({ issues, onSelectIssueIndex }: IssuesPanelProps) {
                     className="issues-panel-item__correction"
                     title={
                       correctionDecisions[index]
-                        ? `Correction: ${correctionDecisions[index]}`
+                        ? `Correction: ${correctionDecisions[index]}${
+                            correctionDecisions[index] === "custom" &&
+                            correctionOverrides[index]
+                              ? " (edited)"
+                              : ""
+                          }`
                         : "Suggested correction available — set choice in Issue details"
                     }
                   >
                     {correctionDecisions[index] ? (
                       <span className="issues-panel-item__decision-badge" aria-hidden>
                         {decisionShortLabel(correctionDecisions[index])}
+                        {correctionDecisions[index] === "custom" &&
+                          correctionOverrides[index] &&
+                          "*"}
                       </span>
                     ) : (
                       <span className="issues-panel-item__correction-pending">Fix</span>

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -5,6 +5,7 @@ import type {
   UploadResponse,
   ValidationJobStatus,
   CorrectionDecision,
+  CorrectionOverride,
   ApplyCorrectionsResponse,
 } from "../types/api";
 import { buildApplyCorrectionsActions } from "../utils/buildApplyCorrectionsRequest";
@@ -32,6 +33,10 @@ type AppContextValue = {
   setCorrectionDecision: (issueIndex: number, decision: CorrectionDecision) => void;
   clearCorrectionDecision: (issueIndex: number) => void;
   resetCorrectionDecisions: () => void;
+  /** Saved manual edits for custom decisions (issue #106). */
+  correctionOverrides: Record<number, CorrectionOverride>;
+  setCorrectionOverride: (issueIndex: number, override: CorrectionOverride) => void;
+  clearCorrectionOverride: (issueIndex: number) => void;
   isApplyingCorrections: boolean;
   applyCorrectionsError: string | null;
   lastApplyCorrectionsResult: ApplyCorrectionsResponse | null;
@@ -49,6 +54,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
   const [correctionDecisions, setCorrectionDecisions] = useState<Record<number, CorrectionDecision>>(
+    {},
+  );
+  const [correctionOverrides, setCorrectionOverrides] = useState<Record<number, CorrectionOverride>>(
     {},
   );
   const [isValidating, setIsValidating] = useState(false);
@@ -73,6 +81,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       setCurrentDataset(data);
       setValidationResult(null);
       setCorrectionDecisions({});
+      setCorrectionOverrides({});
       setValidationError(null);
       setApplyCorrectionsError(null);
       setLastApplyCorrectionsResult(null);
@@ -95,6 +104,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setValidationError(null);
     setValidationResult(null);
     setCorrectionDecisions({});
+    setCorrectionOverrides({});
     setApplyCorrectionsError(null);
     setLastApplyCorrectionsResult(null);
     setIsValidating(true);
@@ -121,6 +131,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         const job = (await jobRes.json()) as ValidationJobStatus;
         if (job.status === "completed" && job.result) {
           setCorrectionDecisions({});
+          setCorrectionOverrides({});
           setValidationResult(job.result);
           break;
         }
@@ -139,6 +150,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   function clearValidation() {
     setValidationResult(null);
     setCorrectionDecisions({});
+    setCorrectionOverrides({});
     setValidationError(null);
     setApplyCorrectionsError(null);
     setLastApplyCorrectionsResult(null);
@@ -146,7 +158,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   async function handleApplyCorrections() {
     if (!currentDataset?.dataset_id || !validationResult) return;
-    const corrections = buildApplyCorrectionsActions(validationResult, correctionDecisions);
+    const corrections = buildApplyCorrectionsActions(
+      validationResult,
+      correctionDecisions,
+      correctionOverrides,
+    );
     if (corrections.length === 0) return;
 
     setApplyCorrectionsError(null);
@@ -184,10 +200,24 @@ export function AppProvider({ children }: { children: ReactNode }) {
       delete next[issueIndex];
       return next;
     });
+    clearCorrectionOverride(issueIndex);
+  }
+
+  function setCorrectionOverride(issueIndex: number, override: CorrectionOverride) {
+    setCorrectionOverrides((prev) => ({ ...prev, [issueIndex]: override }));
+  }
+
+  function clearCorrectionOverride(issueIndex: number) {
+    setCorrectionOverrides((prev) => {
+      const next = { ...prev };
+      delete next[issueIndex];
+      return next;
+    });
   }
 
   function resetCorrectionDecisions() {
     setCorrectionDecisions({});
+    setCorrectionOverrides({});
   }
 
   function dismissLastApplyResult() {
@@ -221,6 +251,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
         setCorrectionDecision,
         clearCorrectionDecision,
         resetCorrectionDecisions,
+        correctionOverrides,
+        setCorrectionOverride,
+        clearCorrectionOverride,
         isApplyingCorrections,
         applyCorrectionsError,
         lastApplyCorrectionsResult,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -462,6 +462,40 @@ calcite-shell .app-main {
   text-decoration: none;
 }
 
+/* Custom correction editor (issue #106) */
+.custom-correction-editor {
+  margin: 0.75rem 0 1rem;
+  padding: 0.75rem;
+  border: 1px solid #d4d4d4;
+  border-radius: 4px;
+  background: #fafafa;
+}
+
+.custom-correction-editor__intro {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.custom-correction-editor__error {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: #c0392b;
+}
+
+.custom-correction-editor__saved {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: #2e7d32;
+}
+
+.custom-correction-editor__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
 .issues-panel-item {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -32,6 +32,13 @@ export type CorrectionSuggestion = {
 /** User choice for a suggested correction (issue #103); persisted until apply or reset. */
 export type CorrectionDecision = "approve" | "reject" | "custom";
 
+/** Manual override for a custom correction (issue #106); sent on apply when action is approve. */
+export type CorrectionOverride = {
+  feature_id?: unknown;
+  geometry_wkt?: string;
+  attributes?: Record<string, unknown>;
+};
+
 /** POST /corrections/apply response (aligned with backend ApplyCorrectionsResponse). */
 export type ApplyCorrectionsResponse = {
   applied: number;

--- a/frontend/src/utils/buildApplyCorrectionsRequest.ts
+++ b/frontend/src/utils/buildApplyCorrectionsRequest.ts
@@ -1,19 +1,26 @@
-import type { CorrectionDecision, ValidationResult } from "../types/api";
+import type {
+  CorrectionDecision,
+  CorrectionOverride,
+  ValidationResult,
+} from "../types/api";
 
 /** API shape for POST /corrections/apply (backend CorrectionAction). */
 export type CorrectionActionPayload = {
   issue_index: number;
   action: "approve" | "reject";
+  feature_id?: unknown;
+  geometry_wkt?: string;
+  attributes?: Record<string, unknown>;
 };
 
 /**
  * Build the corrections list from UI state. Only includes indices that have a
- * matching CorrectionSuggestion. Maps "custom" to approve (same suggestion until
- * override payload exists; see issue #106).
+ * matching CorrectionSuggestion. Custom decisions require a saved override (issue #106).
  */
 export function buildApplyCorrectionsActions(
   validationResult: ValidationResult,
   correctionDecisions: Record<number, CorrectionDecision>,
+  correctionOverrides: Record<number, CorrectionOverride> = {},
 ): CorrectionActionPayload[] {
   const withSuggestion = new Set(
     (validationResult.corrections ?? []).map((c) => c.issue_index),
@@ -24,10 +31,32 @@ export function buildApplyCorrectionsActions(
     if (Number.isNaN(issueIndex) || !withSuggestion.has(issueIndex)) continue;
     if (decision === "reject") {
       list.push({ issue_index: issueIndex, action: "reject" });
-    } else {
-      list.push({ issue_index: issueIndex, action: "approve" });
+      continue;
     }
+    if (decision === "custom") {
+      const override = correctionOverrides[issueIndex];
+      if (!override) continue;
+      list.push({
+        issue_index: issueIndex,
+        action: "approve",
+        ...(override.feature_id !== undefined ? { feature_id: override.feature_id } : {}),
+        ...(override.geometry_wkt ? { geometry_wkt: override.geometry_wkt } : {}),
+        ...(override.attributes ? { attributes: override.attributes } : {}),
+      });
+      continue;
+    }
+    list.push({ issue_index: issueIndex, action: "approve" });
   }
   list.sort((a, b) => a.issue_index - b.issue_index);
   return list;
+}
+
+/** True when any custom decision lacks a saved override (blocks apply). */
+export function hasPendingCustomCorrections(
+  correctionDecisions: Record<number, CorrectionDecision>,
+  correctionOverrides: Record<number, CorrectionOverride>,
+): boolean {
+  return Object.entries(correctionDecisions).some(
+    ([idx, decision]) => decision === "custom" && correctionOverrides[Number(idx)] === undefined,
+  );
 }

--- a/frontend/src/utils/findFeatureInCollection.ts
+++ b/frontend/src/utils/findFeatureInCollection.ts
@@ -1,0 +1,36 @@
+export type GeoJsonFeature = {
+  type: "Feature";
+  id?: string | number;
+  properties?: Record<string, unknown> | null;
+  geometry?: unknown;
+};
+
+export type GeoJsonFeatureCollection = {
+  type: "FeatureCollection";
+  features: GeoJsonFeature[];
+};
+
+/** Locate a feature in a GeoJSON FeatureCollection by feature_id from validation issues. */
+export function findFeatureInCollection(
+  collection: GeoJsonFeatureCollection,
+  featureId: unknown,
+): GeoJsonFeature | null {
+  if (!collection?.features?.length || featureId === undefined || featureId === null) {
+    return null;
+  }
+  const idStr = String(featureId);
+  for (const feature of collection.features) {
+    const props = feature.properties ?? {};
+    if (props.id !== undefined && String(props.id) === idStr) {
+      return feature;
+    }
+    if (feature.id !== undefined && String(feature.id) === idStr) {
+      return feature;
+    }
+  }
+  const asIndex = Number(featureId);
+  if (!Number.isNaN(asIndex) && asIndex >= 0 && asIndex < collection.features.length) {
+    return collection.features[asIndex] ?? null;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add Custom correction editor in the dashboard (geometry WKT and attribute JSON) before applying corrections.
- Extend apply-corrections API and server-side applier to write overrides into dataset GeoJSON.
- Document limitations (no interactive map editing; approve without overrides unchanged).

Closes #106

## Test plan
- [ ] Validate a dataset, choose Custom on an issue, save WKT/JSON, and apply corrections.
- [ ] Download GeoJSON and confirm overrides are reflected.
- [ ] Confirm Apply is blocked until all Custom issues have saved fixes.
- [ ] Run `python -m pytest backend/tests/test_correction_applier.py backend/tests/test_api.py`