### PR TITLE
feat(#12): Quality report generation

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -123,6 +123,39 @@ class ValidateRequest(BaseModel):
     dataset_id: str = Field(..., description="Dataset identifier (from upload) to validate")
 
 
+class TopologyChecksConfig(BaseModel):
+    """Topology validation toggles exposed in reports (issue #12)."""
+
+    gaps: bool = True
+    overlaps: bool = True
+    connectivity: bool = True
+
+
+class ValidationConfigResponse(BaseModel):
+    """Public validation pipeline settings for quality reports (issue #12)."""
+
+    pipeline_steps: List[str] = Field(
+        ...,
+        description="Ordered LangGraph pipeline steps",
+    )
+    geometry_validation_enabled: bool = True
+    attribute_sample_size: int = 500
+    attribute_max_records_in_prompt: int = 10
+    openai_model: str = "gpt-4o-mini"
+    topology_checks: TopologyChecksConfig = Field(default_factory=TopologyChecksConfig)
+
+
+class QualityReportRequest(BaseModel):
+    """Client-built quality report document for server-side export (issue #12)."""
+
+    generated_at: str
+    dataset: UploadResponse
+    validation: ValidationResult
+    summary: Dict[str, Any] = Field(..., description="Issue summary counts and breakdowns")
+    correction_decisions: Optional[Dict[str, Any]] = None
+    validation_config: Optional[ValidationConfigResponse] = None
+
+
 class ErrorResponse(BaseModel):
     """Standard error response for failed requests."""
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,17 +1,20 @@
 """API route handlers."""
 from io import BytesIO
 from pathlib import Path
+from typing import Literal
 import uuid
 
-from fastapi import APIRouter, BackgroundTasks, File, HTTPException, UploadFile
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, UploadFile
+from fastapi.responses import FileResponse, Response
 from api.models import (
     ApplyCorrectionsRequest,
     ApplyCorrectionsResponse,
     CorrectionAction,
     ErrorCode,
     ErrorResponse,
+    QualityReportRequest,
     UploadResponse,
+    ValidationConfigResponse,
     ValidationJobStatus,
     ValidateRequest,
     ValidationResult,
@@ -25,6 +28,7 @@ from services.file_handler import (
     save_upload,
 )
 from services.correction_applier import apply_correction_overrides
+from services.report_builder import export_report_bytes, get_validation_config
 from services.geojson_parser import parse_geojson_metadata
 from services.shapefile_parser import parse_shapefile_metadata
 from agents.orchestrator import empty_state, validation_graph
@@ -380,4 +384,44 @@ async def apply_corrections(body: ApplyCorrectionsRequest):
         skipped=skipped,
         download_url=download_url,
         export_note=export_note,
+    )
+
+
+@router.get(
+    "/validation/config",
+    response_model=ValidationConfigResponse,
+    responses={200: {"description": "Public validation pipeline settings for reports"}},
+)
+async def get_validation_config_endpoint():
+    """Return validation settings used for quality reports (issue #12)."""
+    return ValidationConfigResponse(**get_validation_config())
+
+
+@router.post(
+    "/reports/export",
+    responses={
+        200: {"description": "Exported quality report file"},
+        400: {"description": "Invalid format", "model": ErrorResponse},
+    },
+)
+async def export_quality_report(
+    body: QualityReportRequest,
+    format: Literal["json", "markdown"] = Query("json", alias="format"),
+):
+    """
+    Export a client-built quality report as JSON or Markdown (issue #12).
+    """
+    payload = body.model_dump()
+    try:
+        content, media_type, filename = export_report_bytes(payload, format)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"detail": str(exc), "code": "INVALID_FORMAT"},
+        ) from exc
+
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )

--- a/backend/services/report_builder.py
+++ b/backend/services/report_builder.py
@@ -1,0 +1,151 @@
+"""Quality report formatting and validation config snapshot (issue #12)."""
+import json
+from typing import Any, Dict, List
+
+from core.config import settings
+
+
+def get_validation_config() -> Dict[str, Any]:
+    """Public validation settings for reports (no secrets)."""
+    return {
+        "pipeline_steps": [
+            "geometry_validation",
+            "attribute_validation",
+            "topology_validation",
+            "generate_recommendations",
+        ],
+        "geometry_validation_enabled": settings.GEOMETRY_VALIDATION_ENABLED,
+        "attribute_sample_size": settings.ATTRIBUTE_SAMPLE_SIZE,
+        "attribute_max_records_in_prompt": settings.ATTRIBUTE_MAX_RECORDS_IN_PROMPT,
+        "openai_model": settings.OPENAI_MODEL,
+        "topology_checks": {
+            "gaps": True,
+            "overlaps": True,
+            "connectivity": True,
+        },
+    }
+
+
+def _format_bounds(bounds: Any) -> str:
+    if not bounds or not isinstance(bounds, list):
+        return "—"
+    return ", ".join(f"{float(x):.4f}" for x in bounds)
+
+
+def render_report_markdown(payload: Dict[str, Any]) -> str:
+    """Render a quality report payload as Markdown (mirrors frontend export)."""
+    dataset = payload.get("dataset") or {}
+    validation = payload.get("validation") or {}
+    summary = payload.get("summary") or {}
+    generated_at = payload.get("generated_at", "")
+    validation_config = payload.get("validation_config")
+    correction_decisions = payload.get("correction_decisions") or {}
+
+    lines: List[str] = []
+    lines.append("# Quality assessment report")
+    lines.append("")
+    lines.append(f"**Dataset:** {dataset.get('filename', '—')}")
+    lines.append(f"**Dataset ID:** {dataset.get('dataset_id', '—')}")
+    lines.append(f"**Generated:** {generated_at}")
+    lines.append("")
+
+    lines.append("## Dataset metadata")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("| --- | --- |")
+    lines.append(f"| Features | {dataset.get('feature_count', '—')} |")
+    lines.append(f"| Geometry type | {dataset.get('geometry_type') or '—'} |")
+    lines.append(f"| CRS | {dataset.get('crs') or '—'} |")
+    lines.append(f"| Bounds | {_format_bounds(dataset.get('bounds'))} |")
+    lines.append("")
+
+    if validation_config:
+        lines.append("## Validation configuration")
+        lines.append("")
+        lines.append("| Setting | Value |")
+        lines.append("| --- | --- |")
+        steps = validation_config.get("pipeline_steps") or []
+        lines.append(f"| Pipeline | {' → '.join(steps)} |")
+        lines.append(
+            f"| Geometry validation | {'enabled' if validation_config.get('geometry_validation_enabled') else 'disabled'} |"
+        )
+        lines.append(f"| Attribute sample size | {validation_config.get('attribute_sample_size', '—')} |")
+        lines.append(
+            f"| Records in LLM prompt | {validation_config.get('attribute_max_records_in_prompt', '—')} |"
+        )
+        lines.append(f"| LLM model | {validation_config.get('openai_model', '—')} |")
+        tc = validation_config.get("topology_checks") or {}
+        lines.append(
+            f"| Topology checks | gaps={tc.get('gaps')}, overlaps={tc.get('overlaps')}, connectivity={tc.get('connectivity')} |"
+        )
+        lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Count |")
+    lines.append("| --- | --- |")
+    lines.append(f"| Total issues | {summary.get('totalIssues', 0)} |")
+    lines.append(f"| Critical | {summary.get('critical', 0)} |")
+    lines.append(f"| Warnings | {summary.get('warning', 0)} |")
+    by_cat = summary.get("byCategory") or {}
+    lines.append(f"| Geometry | {by_cat.get('geometry', 0)} |")
+    lines.append(f"| Attribute | {by_cat.get('attribute', 0)} |")
+    lines.append(f"| Topology | {by_cat.get('topology', 0)} |")
+    lines.append("")
+
+    corrections = validation.get("corrections") or []
+    lines.append("## Corrections")
+    lines.append("")
+    lines.append(f"Suggested corrections: {len(corrections)}")
+    if correction_decisions:
+        lines.append("")
+        lines.append("| Issue index | Decision | Custom override |")
+        lines.append("| --- | --- | --- |")
+        for idx, entry in correction_decisions.items():
+            if isinstance(entry, dict):
+                decision = entry.get("decision", "—")
+                has_override = "yes" if entry.get("hasOverride") else "no"
+            else:
+                decision = str(entry)
+                has_override = "no"
+            lines.append(f"| {idx} | {decision} | {has_override} |")
+    lines.append("")
+
+    issues = validation.get("issues") or []
+    limit = 500
+    shown = issues[:limit]
+    suffix = f" of {len(issues)}" if len(issues) > len(shown) else ""
+    lines.append(f"## Issues ({len(shown)}{suffix})")
+    lines.append("")
+    lines.append("| # | Type | Severity | Feature | Description |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for i, issue in enumerate(shown):
+        fid = issue.get("feature_id")
+        fid_str = str(fid) if fid is not None else "—"
+        desc = (issue.get("description") or "").replace("|", "\\|")[:120]
+        lines.append(
+            f"| {i} | {issue.get('type', '')} | {issue.get('severity', '')} | {fid_str} | {desc} |"
+        )
+    if len(issues) > len(shown):
+        lines.append("")
+        lines.append(f"_…and {len(issues) - len(shown)} more issues not listed._")
+
+    return "\n".join(lines)
+
+
+def export_report_bytes(payload: Dict[str, Any], fmt: str) -> tuple[bytes, str, str]:
+    """
+    Return (content_bytes, media_type, filename_suffix) for the given format.
+    fmt: 'json' or 'markdown'
+    """
+    dataset = payload.get("dataset") or {}
+    base = (dataset.get("filename") or "quality-report").replace(" ", "_")
+    safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in base)[:80] or "quality-report"
+
+    if fmt == "markdown":
+        content = render_report_markdown(payload).encode("utf-8")
+        return content, "text/markdown; charset=utf-8", f"{safe}-report.md"
+    if fmt == "json":
+        content = json.dumps(payload, indent=2).encode("utf-8")
+        return content, "application/json", f"{safe}-report.json"
+    raise ValueError(f"Unsupported format: {fmt}")

--- a/backend/tests/test_report.py
+++ b/backend/tests/test_report.py
@@ -1,0 +1,110 @@
+"""Tests for quality report endpoints (issue #12)."""
+import json
+
+from services.report_builder import export_report_bytes, get_validation_config, render_report_markdown
+
+
+def _sample_payload() -> dict:
+    return {
+        "generated_at": "2026-05-16T12:00:00Z",
+        "dataset": {
+            "dataset_id": "test-dataset",
+            "filename": "sample.geojson",
+            "feature_count": 10,
+            "geometry_type": "Polygon",
+            "crs": "EPSG:4326",
+            "bounds": [-1.0, -1.0, 1.0, 1.0],
+        },
+        "validation": {
+            "dataset_id": "test-dataset",
+            "issues": [
+                {
+                    "feature_id": 0,
+                    "type": "invalid_geometry",
+                    "severity": "critical",
+                    "description": "Invalid ring",
+                },
+                {
+                    "feature_id": 1,
+                    "type": "attribute_missing",
+                    "severity": "warning",
+                    "description": "Missing field",
+                },
+            ],
+            "corrections": [
+                {
+                    "method": "buffer(0)",
+                    "confidence": 0.9,
+                    "explanation": "Fix geometry",
+                    "issue_index": 0,
+                }
+            ],
+        },
+        "summary": {
+            "totalIssues": 2,
+            "critical": 1,
+            "warning": 1,
+            "byCategory": {"geometry": 1, "attribute": 1, "topology": 0},
+            "byType": {"invalid_geometry": 1, "attribute_missing": 1},
+        },
+        "validation_config": get_validation_config(),
+    }
+
+
+def test_get_validation_config():
+    cfg = get_validation_config()
+    assert cfg["geometry_validation_enabled"] is True
+    assert "geometry_validation" in cfg["pipeline_steps"][0]
+    assert cfg["topology_checks"]["gaps"] is True
+
+
+def test_render_report_markdown():
+    md = render_report_markdown(_sample_payload())
+    assert "# Quality assessment report" in md
+    assert "sample.geojson" in md
+    assert "invalid_geometry" in md
+
+
+def test_export_report_bytes_json():
+    content, media_type, filename = export_report_bytes(_sample_payload(), "json")
+    assert media_type == "application/json"
+    assert filename.endswith(".json")
+    data = json.loads(content.decode("utf-8"))
+    assert data["dataset"]["dataset_id"] == "test-dataset"
+
+
+def test_export_report_bytes_markdown():
+    content, media_type, filename = export_report_bytes(_sample_payload(), "markdown")
+    assert "text/markdown" in media_type
+    assert filename.endswith(".md")
+    assert b"Quality assessment report" in content
+
+
+def test_validation_config_endpoint(client):
+    res = client.get("/api/v1/validation/config")
+    assert res.status_code == 200
+    data = res.json()
+    assert "pipeline_steps" in data
+    assert data["openai_model"]
+
+
+def test_export_report_endpoint_json(client):
+    res = client.post(
+        "/api/v1/reports/export?format=json",
+        json=_sample_payload(),
+    )
+    assert res.status_code == 200
+    assert "application/json" in res.headers.get("content-type", "")
+    assert "attachment" in res.headers.get("content-disposition", "").lower()
+    data = res.json()
+    assert data["summary"]["totalIssues"] == 2
+
+
+def test_export_report_endpoint_markdown(client):
+    res = client.post(
+        "/api/v1/reports/export?format=markdown",
+        json=_sample_payload(),
+    )
+    assert res.status_code == 200
+    assert "text/markdown" in res.headers.get("content-type", "")
+    assert b"Quality assessment report" in res.content

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,4 +1,8 @@
 node_modules
 dist
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 .env
 *.local

--- a/frontend/e2e/report.spec.ts
+++ b/frontend/e2e/report.spec.ts
@@ -1,0 +1,184 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sampleGeojson = path.resolve(__dirname, "../../backend/resources/sample.geojson");
+
+const MOCK_JOB_ID = "e2e-mock-validation-job";
+
+function mockValidationSuccess(page: Page) {
+  let capturedDatasetId = "";
+
+  page.route("**/api/v1/validate/async", async (route) => {
+    const body = route.request().postDataJSON() as { dataset_id: string };
+    capturedDatasetId = body.dataset_id;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: MOCK_JOB_ID,
+        dataset_id: capturedDatasetId,
+        status: "pending",
+        error: null,
+        result: null,
+      }),
+    });
+  });
+
+  page.route(`**/api/v1/validate/jobs/${MOCK_JOB_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: MOCK_JOB_ID,
+        dataset_id: capturedDatasetId,
+        status: "completed",
+        error: null,
+        result: {
+          dataset_id: capturedDatasetId,
+          issues: [
+            {
+              feature_id: 1,
+              type: "invalid_geometry",
+              severity: "critical",
+              description: "E2E mock geometry issue",
+            },
+            {
+              feature_id: 2,
+              type: "attribute_typo",
+              severity: "warning",
+              description: "E2E mock attribute issue",
+            },
+          ],
+          corrections: [
+            {
+              method: "buffer(0)",
+              confidence: 0.9,
+              explanation: "Fix invalid polygon",
+              issue_index: 0,
+            },
+          ],
+        },
+      }),
+    });
+  });
+}
+
+async function uploadDataset(page: Page) {
+  await page.goto("/#/upload");
+  await page.locator('input[type="file"]').setInputFiles(sampleGeojson);
+  await expect(page.getByText(/Loaded:\s*sample\.geojson/i)).toBeVisible({ timeout: 30_000 });
+}
+
+async function uploadAndValidate(page: Page) {
+  mockValidationSuccess(page);
+  await uploadDataset(page);
+
+  await page.goto("/#/dashboard");
+  await page.getByRole("button", { name: /^Run validation$/i }).click();
+  await expect(page.getByText(/Validation in progress/i)).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(/Validation in progress/i)).toBeHidden({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: /Open quality report/i })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+function viewReportButton(page: Page) {
+  return page.getByRole("button", { name: /Open quality report/i });
+}
+
+test.describe("Quality report (issue #12)", () => {
+  test("validation config API is available", async ({ request }) => {
+    const res = await request.get("/api/v1/validation/config");
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    expect(data.pipeline_steps).toContain("geometry_validation");
+    expect(data.openai_model).toBeTruthy();
+  });
+
+  test("report page shows empty state before upload", async ({ page }) => {
+    await page.goto("/#/report");
+    await expect(page.getByRole("heading", { name: /Quality report/i })).toBeVisible();
+    await expect(page.getByText(/Upload a dataset on the/i)).toBeVisible();
+  });
+
+  test("report page shows empty state when dataset uploaded but not validated", async ({
+    page,
+  }) => {
+    await uploadDataset(page);
+    await page.goto("/#/report");
+    await expect(page.getByText(/Run validation on the/i)).toBeVisible();
+  });
+
+  test("full flow: validate then view report with exports", async ({ page }) => {
+    await uploadAndValidate(page);
+
+    await viewReportButton(page).click();
+    await expect(page).toHaveURL(/#\/report/);
+
+    await expect(page.getByRole("heading", { name: /Quality assessment report/i })).toBeVisible();
+    await expect(page.getByText(/sample\.geojson/i).first()).toBeVisible();
+    await expect(page.getByText(/Validation configuration/i)).toBeVisible();
+    await expect(page.getByText(/Total issues/i)).toBeVisible();
+    await expect(page.getByRole("cell", { name: "invalid_geometry" }).first()).toBeVisible();
+
+    await expect(page.getByRole("button", { name: /Download report as JSON/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Download report as Markdown/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Print or save as PDF/i })).toBeVisible();
+
+    const [jsonDownload] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("button", { name: /Download report as JSON/i }).click(),
+    ]);
+    expect(jsonDownload.suggestedFilename()).toMatch(/report\.json$/i);
+
+    const [mdDownload] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("button", { name: /Download report as Markdown/i }).click(),
+    ]);
+    expect(mdDownload.suggestedFilename()).toMatch(/report\.md$/i);
+  });
+
+  test("server export endpoint returns markdown attachment", async ({ request }) => {
+    const payload = {
+      generated_at: new Date().toISOString(),
+      dataset: {
+        dataset_id: "e2e-test",
+        filename: "sample.geojson",
+        feature_count: 3,
+        geometry_type: "Point",
+        crs: "EPSG:4326",
+        bounds: [-122.43, 37.77, -122.41, 37.79],
+      },
+      validation: {
+        dataset_id: "e2e-test",
+        issues: [
+          {
+            feature_id: 0,
+            type: "invalid_geometry",
+            severity: "critical",
+            description: "Test issue",
+          },
+        ],
+        corrections: [],
+      },
+      summary: {
+        totalIssues: 1,
+        critical: 1,
+        warning: 0,
+        byCategory: { geometry: 1, attribute: 0, topology: 0 },
+        byType: { invalid_geometry: 1 },
+      },
+    };
+
+    const res = await request.post("/api/v1/reports/export?format=markdown", {
+      data: payload,
+    });
+    expect(res.ok()).toBeTruthy();
+    expect(res.headers()["content-type"]).toContain("text/markdown");
+    const body = await res.text();
+    expect(body).toContain("# Quality assessment report");
+    expect(body).toContain("invalid_geometry");
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.2.0",
@@ -1014,6 +1015,22 @@
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1979,6 +1996,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@arcgis/core": "^4.28.7",
@@ -16,6 +18,7 @@
     "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const backendDir = path.resolve(__dirname, "../backend");
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+    acceptDownloads: true,
+  },
+  webServer: [
+    {
+      command: "python -m uvicorn main:app --host 127.0.0.1 --port 8000",
+      cwd: backendDir,
+      url: "http://127.0.0.1:8000/health",
+      reuseExistingServer: true,
+      timeout: 180_000,
+    },
+    {
+      command: "npm run build && npm run preview -- --host 127.0.0.1 --port 4173",
+      cwd: __dirname,
+      url: "http://127.0.0.1:4173",
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000,
+    },
+  ],
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { UploadPage } from "./pages/UploadPage";
 import { MapPage } from "./pages/MapPage";
 import { StatusPage } from "./pages/StatusPage";
 import { DashboardPage } from "./components/Dashboard/DashboardPage";
+import { ReportPage } from "./pages/ReportPage";
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
             <Route path="upload" element={<UploadPage />} />
             <Route path="map" element={<MapPage />} />
             <Route path="status" element={<StatusPage />} />
+            <Route path="report" element={<ReportPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   CalcitePanel,
   CalciteButton,
@@ -36,6 +37,7 @@ export function DashboardPage() {
     clearValidationError,
     clearApplyCorrectionsError,
   } = useApp();
+  const navigate = useNavigate();
   const [selectedIssueIndex, setSelectedIssueIndex] = useState<number | null>(null);
   const [validateConfirmOpen, setValidateConfirmOpen] = useState(false);
 
@@ -120,6 +122,16 @@ export function DashboardPage() {
             >
               {isValidating ? "Validating…" : "Run validation"}
             </CalciteButton>
+            {validationResult ? (
+              <CalciteButton
+                kind="neutral"
+                appearance="outline"
+                onClick={() => navigate("/report")}
+                label="Open quality report"
+              >
+                View report
+              </CalciteButton>
+            ) : null}
             <CalciteButton
               kind="neutral"
               onClick={handleApplyCorrections}

--- a/frontend/src/components/Dashboard/IssuesPanel.tsx
+++ b/frontend/src/components/Dashboard/IssuesPanel.tsx
@@ -8,6 +8,7 @@ import {
 
 import type { CorrectionDecision, GeometryIssue } from "../../types/api";
 import { useApp } from "../../context/AppContext";
+import { categorizeIssueType } from "../../utils/reportSummary";
 
 export type IssuesPanelProps = {
   issues: GeometryIssue[];
@@ -16,12 +17,6 @@ export type IssuesPanelProps = {
 
 type TypeFilter = "all" | "geometry" | "attribute" | "topology";
 type SeverityFilter = "all" | "critical" | "warning";
-
-function categorizeType(type: string): TypeFilter {
-  if (type.startsWith("attribute_")) return "attribute";
-  if (type.startsWith("topology_")) return "topology";
-  return "geometry";
-}
 
 function correctionIndicesFromIssues(
   issues: GeometryIssue[],
@@ -62,7 +57,7 @@ export function IssuesPanel({ issues, onSelectIssueIndex }: IssuesPanelProps) {
     return issues
       .map((issue, index) => ({ issue, index }))
       .filter(({ issue }) => {
-      const t = categorizeType(issue.type || "");
+      const t = categorizeIssueType(issue.type || "");
       if (typeFilter !== "all" && t !== typeFilter) return false;
 
       const sev = (issue.severity || "").toLowerCase();

--- a/frontend/src/components/Dashboard/SummaryStats.tsx
+++ b/frontend/src/components/Dashboard/SummaryStats.tsx
@@ -1,4 +1,5 @@
 import type { GeometryIssue } from "../../types/api";
+import { computeIssueSummary } from "../../utils/reportSummary";
 
 export type SummaryStatsProps = {
   totalFeatures?: number | null;
@@ -6,9 +7,7 @@ export type SummaryStatsProps = {
 };
 
 export function SummaryStats({ totalFeatures, issues }: SummaryStatsProps) {
-  const totalIssues = issues.length;
-  const critical = issues.filter((i) => i.severity.toLowerCase() === "critical").length;
-  const warning = issues.filter((i) => i.severity.toLowerCase() === "warning").length;
+  const { totalIssues, critical, warning } = computeIssueSummary(issues);
 
   return (
     <div className="summary-stats">

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -41,6 +41,12 @@ export function AppLayout() {
             >
               Status
             </NavLink>
+            <NavLink
+              to="/report"
+              className={({ isActive }) => `app-nav-link${isActive ? " app-nav-link--active" : ""}`}
+            >
+              Report
+            </NavLink>
           </nav>
         </CalciteNavigation>
       </div>

--- a/frontend/src/components/Report/QualityReport.tsx
+++ b/frontend/src/components/Report/QualityReport.tsx
@@ -1,0 +1,300 @@
+import { CalciteButton, CalcitePanel } from "@esri/calcite-components-react";
+
+import type { QualityReportPayload } from "../../utils/reportSummary";
+import { APPENDIX_ISSUE_LIMIT } from "../../utils/reportSummary";
+import { downloadJson, downloadMarkdown, printReport } from "../../utils/exportReport";
+
+export type QualityReportProps = {
+  payload: QualityReportPayload;
+};
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function formatBounds(bounds: number[] | null | undefined): string {
+  if (!bounds?.length) return "—";
+  return bounds.map((n) => n.toFixed(4)).join(", ");
+}
+
+type BarChartProps = {
+  label: string;
+  segments: { name: string; value: number; className: string }[];
+  total: number;
+};
+
+function BarChart({ label, segments, total }: BarChartProps) {
+  const max = Math.max(total, 1);
+  return (
+    <div className="quality-report-chart">
+      <p className="quality-report-chart__title">{label}</p>
+      <div className="quality-report-chart__bars" role="img" aria-label={label}>
+        {segments.map((seg) => (
+          <div key={seg.name} className="quality-report-chart__row">
+            <span className="quality-report-chart__label">{seg.name}</span>
+            <span className="quality-report-chart__track">
+              <span
+                className={`quality-report-chart__fill ${seg.className}`}
+                style={{ width: `${(seg.value / max) * 100}%` }}
+              />
+            </span>
+            <span className="quality-report-chart__value">{seg.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function QualityReport({ payload }: QualityReportProps) {
+  const { dataset, validation, summary, generated_at, validation_config, correction_decisions } =
+    payload;
+
+  const filenameBase = dataset.filename.replace(/\.[^.]+$/, "") || dataset.dataset_id;
+  const issues = validation.issues;
+  const appendixIssues = issues.slice(0, APPENDIX_ISSUE_LIMIT);
+  const corrections = validation.corrections ?? [];
+
+  const topTypes = Object.entries(summary.byType)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8);
+
+  const decisionCounts = { approve: 0, reject: 0, custom: 0 };
+  if (correction_decisions) {
+    for (const entry of Object.values(correction_decisions)) {
+      if (entry.decision in decisionCounts) {
+        decisionCounts[entry.decision as keyof typeof decisionCounts] += 1;
+      }
+    }
+  }
+
+  return (
+    <div className="quality-report">
+      <div className="quality-report__toolbar no-print">
+        <CalciteButton
+          appearance="outline"
+          onClick={() => downloadJson(payload, filenameBase)}
+          label="Download report as JSON"
+        >
+          Download JSON
+        </CalciteButton>
+        <CalciteButton
+          appearance="outline"
+          onClick={() => downloadMarkdown(payload, filenameBase)}
+          label="Download report as Markdown"
+        >
+          Download Markdown
+        </CalciteButton>
+        <CalciteButton appearance="solid" onClick={() => printReport()} label="Print or save as PDF">
+          Print / Save as PDF
+        </CalciteButton>
+      </div>
+
+      <div id="quality-report-print-root" className="quality-report__body">
+        <header className="quality-report__header">
+          <h3 className="quality-report__title">Quality assessment report</h3>
+          <p className="quality-report__meta">
+            <strong>{dataset.filename}</strong> · {dataset.dataset_id}
+          </p>
+          <p className="quality-report__meta">Generated {formatTimestamp(generated_at)}</p>
+        </header>
+
+        <CalcitePanel heading="Dataset metadata" className="quality-report__panel">
+          <dl className="quality-report__dl">
+            <div>
+              <dt>Features</dt>
+              <dd>{typeof dataset.feature_count === "number" ? dataset.feature_count : "—"}</dd>
+            </div>
+            <div>
+              <dt>Geometry type</dt>
+              <dd>{dataset.geometry_type ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>CRS</dt>
+              <dd>{dataset.crs ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>Bounds</dt>
+              <dd>{formatBounds(dataset.bounds)}</dd>
+            </div>
+          </dl>
+        </CalcitePanel>
+
+        {validation_config ? (
+          <CalcitePanel heading="Validation configuration" className="quality-report__panel">
+            <dl className="quality-report__dl">
+              <div>
+                <dt>Pipeline</dt>
+                <dd>{validation_config.pipeline_steps.join(" → ")}</dd>
+              </div>
+              <div>
+                <dt>Geometry validation</dt>
+                <dd>{validation_config.geometry_validation_enabled ? "Enabled" : "Disabled"}</dd>
+              </div>
+              <div>
+                <dt>Attribute sample size</dt>
+                <dd>{validation_config.attribute_sample_size}</dd>
+              </div>
+              <div>
+                <dt>Records in LLM prompt</dt>
+                <dd>{validation_config.attribute_max_records_in_prompt}</dd>
+              </div>
+              <div>
+                <dt>LLM model</dt>
+                <dd>{validation_config.openai_model}</dd>
+              </div>
+              <div>
+                <dt>Topology checks</dt>
+                <dd>
+                  Gaps {validation_config.topology_checks.gaps ? "on" : "off"}, overlaps{" "}
+                  {validation_config.topology_checks.overlaps ? "on" : "off"}, connectivity{" "}
+                  {validation_config.topology_checks.connectivity ? "on" : "off"}
+                </dd>
+              </div>
+            </dl>
+          </CalcitePanel>
+        ) : null}
+
+        <CalcitePanel heading="Summary" className="quality-report__panel">
+          <div className="summary-stats">
+            <div className="summary-stats__item">
+              <span className="summary-stats__label">Total issues</span>
+              <span className="summary-stats__value">{summary.totalIssues}</span>
+            </div>
+            <div className="summary-stats__item">
+              <span className="summary-stats__label">Critical</span>
+              <span className="summary-stats__value">{summary.critical}</span>
+            </div>
+            <div className="summary-stats__item">
+              <span className="summary-stats__label">Warnings</span>
+              <span className="summary-stats__value">{summary.warning}</span>
+            </div>
+          </div>
+
+          <div className="quality-report__charts">
+            <BarChart
+              label="By severity"
+              total={summary.totalIssues}
+              segments={[
+                {
+                  name: "Critical",
+                  value: summary.critical,
+                  className: "quality-report-chart__fill--critical",
+                },
+                {
+                  name: "Warning",
+                  value: summary.warning,
+                  className: "quality-report-chart__fill--warning",
+                },
+              ]}
+            />
+            <BarChart
+              label="By category"
+              total={summary.totalIssues}
+              segments={[
+                {
+                  name: "Geometry",
+                  value: summary.byCategory.geometry,
+                  className: "quality-report-chart__fill--geometry",
+                },
+                {
+                  name: "Attribute",
+                  value: summary.byCategory.attribute,
+                  className: "quality-report-chart__fill--attribute",
+                },
+                {
+                  name: "Topology",
+                  value: summary.byCategory.topology,
+                  className: "quality-report-chart__fill--topology",
+                },
+              ]}
+            />
+          </div>
+        </CalcitePanel>
+
+        <CalcitePanel heading="Issue breakdown" className="quality-report__panel">
+          {topTypes.length > 0 ? (
+            <table className="quality-report__table">
+              <thead>
+                <tr>
+                  <th scope="col">Issue type</th>
+                  <th scope="col">Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topTypes.map(([type, count]) => (
+                  <tr key={type}>
+                    <td>{type}</td>
+                    <td>{count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="empty-state">No issues recorded.</p>
+          )}
+        </CalcitePanel>
+
+        <CalcitePanel heading="Corrections" className="quality-report__panel">
+          <p>Suggested corrections: {corrections.length}</p>
+          {correction_decisions && Object.keys(correction_decisions).length > 0 ? (
+            <ul className="quality-report__decisions">
+              <li>Approved: {decisionCounts.approve}</li>
+              <li>Rejected: {decisionCounts.reject}</li>
+              <li>Custom: {decisionCounts.custom}</li>
+            </ul>
+          ) : (
+            <p className="quality-report__hint">No user correction decisions recorded for this run.</p>
+          )}
+        </CalcitePanel>
+
+        <CalcitePanel heading="Issues" className="quality-report__panel quality-report__panel--issues">
+          {appendixIssues.length === 0 ? (
+            <p className="empty-state">No issues found.</p>
+          ) : (
+            <>
+              <div className="quality-report__table-wrap">
+                <table className="quality-report__table quality-report__table--issues">
+                  <thead>
+                    <tr>
+                      <th scope="col">#</th>
+                      <th scope="col">Type</th>
+                      <th scope="col">Severity</th>
+                      <th scope="col">Feature</th>
+                      <th scope="col">Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {appendixIssues.map((issue, index) => (
+                      <tr key={index}>
+                        <td>{index}</td>
+                        <td>{issue.type}</td>
+                        <td>{issue.severity}</td>
+                        <td>
+                          {issue.feature_id !== undefined && issue.feature_id !== null
+                            ? String(issue.feature_id)
+                            : "—"}
+                        </td>
+                        <td>{issue.description ?? "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {issues.length > appendixIssues.length ? (
+                <p className="quality-report__hint">
+                  Showing {appendixIssues.length} of {issues.length} issues. Export JSON or Markdown
+                  for the full list.
+                </p>
+              ) : null}
+            </>
+          )}
+        </CalcitePanel>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -556,3 +556,178 @@ calcite-shell .app-main {
     flex-direction: row;
   }
 }
+
+/* Quality report (issue #12) */
+.page-section--report {
+  max-width: 960px;
+}
+
+.quality-report__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.quality-report__header {
+  margin-bottom: 1rem;
+}
+
+.quality-report__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.35rem;
+}
+
+.quality-report__meta {
+  margin: 0.15rem 0;
+  font-size: 0.9rem;
+  color: #4a4a4a;
+}
+
+.quality-report__panel {
+  margin-bottom: 1rem;
+}
+
+.quality-report__dl {
+  display: grid;
+  grid-template-columns: minmax(8rem, auto) 1fr;
+  gap: 0.35rem 1rem;
+  margin: 0;
+}
+
+.quality-report__dl > div {
+  display: contents;
+}
+
+.quality-report__dl dt {
+  font-weight: 600;
+  color: #4a4a4a;
+}
+
+.quality-report__dl dd {
+  margin: 0;
+}
+
+.quality-report__charts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+@media (min-width: 768px) {
+  .quality-report__charts {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.quality-report-chart__title {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.quality-report-chart__row {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr 2rem;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.quality-report-chart__track {
+  height: 0.65rem;
+  background: #e8e8e8;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.quality-report-chart__fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 3px;
+}
+
+.quality-report-chart__fill--critical {
+  background: #c0392b;
+}
+
+.quality-report-chart__fill--warning {
+  background: #e67e22;
+}
+
+.quality-report-chart__fill--geometry {
+  background: #0079c1;
+}
+
+.quality-report-chart__fill--attribute {
+  background: #8844d8;
+}
+
+.quality-report-chart__fill--topology {
+  background: #2e7d32;
+}
+
+.quality-report-chart__value {
+  font-size: 0.85rem;
+  text-align: right;
+}
+
+.quality-report__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.quality-report__table th,
+.quality-report__table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid #e8e8e8;
+  text-align: left;
+  vertical-align: top;
+}
+
+.quality-report__table th {
+  font-weight: 600;
+  background: #f5f5f5;
+}
+
+.quality-report__table-wrap {
+  max-height: 24rem;
+  overflow: auto;
+}
+
+.quality-report__hint {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: #6a6a6a;
+}
+
+.quality-report__decisions {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+@media print {
+  .no-print,
+  calcite-shell-panel,
+  .app-nav,
+  .skip-link,
+  calcite-navigation {
+    display: none !important;
+  }
+
+  .app-main {
+    padding: 0 !important;
+  }
+
+  .quality-report__panel {
+    break-inside: avoid;
+  }
+
+  .quality-report__table-wrap {
+    max-height: none;
+    overflow: visible;
+  }
+}

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { QualityReport } from "../components/Report/QualityReport";
+import { useApp } from "../context/AppContext";
+import type { ValidationConfigResponse } from "../types/api";
+import { buildQualityReportPayload } from "../utils/reportSummary";
+
+export function ReportPage() {
+  const {
+    currentDataset,
+    validationResult,
+    correctionDecisions,
+    correctionOverrides,
+  } = useApp();
+  const [validationConfig, setValidationConfig] = useState<ValidationConfigResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/v1/validation/config");
+        if (!res.ok) return;
+        const data = (await res.json()) as ValidationConfigResponse;
+        if (!cancelled) setValidationConfig(data);
+      } catch {
+        /* use defaults in buildQualityReportPayload */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const payload = useMemo(() => {
+    if (!currentDataset || !validationResult) return null;
+    return buildQualityReportPayload(currentDataset, validationResult, {
+      correctionDecisions,
+      correctionOverrides,
+      validationConfig,
+    });
+  }, [
+    currentDataset,
+    validationResult,
+    correctionDecisions,
+    correctionOverrides,
+    validationConfig,
+  ]);
+
+  return (
+    <section className="page-section page-section--report" aria-labelledby="report-heading">
+      <h2 id="report-heading" className="page-heading">
+        Quality report
+      </h2>
+      {!currentDataset ? (
+        <p className="empty-state">
+          Upload a dataset on the <Link to="/upload">Upload</Link> page first.
+        </p>
+      ) : !validationResult ? (
+        <p className="empty-state">
+          Run validation on the <Link to="/dashboard">Dashboard</Link> to generate a report.
+        </p>
+      ) : payload ? (
+        <QualityReport payload={payload} />
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -19,7 +19,23 @@ export type UploadResponse = {
   filename: string;
   /** Optional total feature count for the dataset (from upload metadata). */
   feature_count?: number;
+  geometry_type?: string | null;
+  crs?: string | null;
   bounds?: number[] | null;
+};
+
+/** GET /validation/config — public validation pipeline settings (issue #12). */
+export type ValidationConfigResponse = {
+  pipeline_steps: string[];
+  geometry_validation_enabled: boolean;
+  attribute_sample_size: number;
+  attribute_max_records_in_prompt: number;
+  openai_model: string;
+  topology_checks: {
+    gaps: boolean;
+    overlaps: boolean;
+    connectivity: boolean;
+  };
 };
 
 export type CorrectionSuggestion = {

--- a/frontend/src/utils/exportReport.ts
+++ b/frontend/src/utils/exportReport.ts
@@ -1,0 +1,131 @@
+import type { QualityReportPayload } from "./reportSummary";
+import { APPENDIX_ISSUE_LIMIT } from "./reportSummary";
+
+function safeFilename(base: string): string {
+  return base.replace(/[^\w.-]+/g, "_").slice(0, 80) || "quality-report";
+}
+
+export function downloadJson(payload: QualityReportPayload, filenameBase: string): void {
+  const name = `${safeFilename(filenameBase)}-report.json`;
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function formatBounds(bounds: number[] | null | undefined): string {
+  if (!bounds?.length) return "—";
+  return bounds.map((n) => n.toFixed(4)).join(", ");
+}
+
+export function renderReportMarkdown(payload: QualityReportPayload): string {
+  const { dataset, validation, summary, generated_at, validation_config, correction_decisions } =
+    payload;
+  const lines: string[] = [];
+
+  lines.push(`# Quality assessment report`);
+  lines.push("");
+  lines.push(`**Dataset:** ${dataset.filename}`);
+  lines.push(`**Dataset ID:** ${dataset.dataset_id}`);
+  lines.push(`**Generated:** ${generated_at}`);
+  lines.push("");
+
+  lines.push(`## Dataset metadata`);
+  lines.push("");
+  lines.push(`| Field | Value |`);
+  lines.push(`| --- | --- |`);
+  lines.push(`| Features | ${dataset.feature_count ?? "—"} |`);
+  lines.push(`| Geometry type | ${dataset.geometry_type ?? "—"} |`);
+  lines.push(`| CRS | ${dataset.crs ?? "—"} |`);
+  lines.push(`| Bounds | ${formatBounds(dataset.bounds)} |`);
+  lines.push("");
+
+  if (validation_config) {
+    lines.push(`## Validation configuration`);
+    lines.push("");
+    lines.push(`| Setting | Value |`);
+    lines.push(`| --- | --- |`);
+    lines.push(`| Pipeline | ${validation_config.pipeline_steps.join(" → ")} |`);
+    lines.push(
+      `| Geometry validation | ${validation_config.geometry_validation_enabled ? "enabled" : "disabled"} |`,
+    );
+    lines.push(`| Attribute sample size | ${validation_config.attribute_sample_size} |`);
+    lines.push(
+      `| Records in LLM prompt | ${validation_config.attribute_max_records_in_prompt} |`,
+    );
+    lines.push(`| LLM model | ${validation_config.openai_model} |`);
+    const tc = validation_config.topology_checks;
+    lines.push(
+      `| Topology checks | gaps=${tc.gaps}, overlaps=${tc.overlaps}, connectivity=${tc.connectivity} |`,
+    );
+    lines.push("");
+  }
+
+  lines.push(`## Summary`);
+  lines.push("");
+  lines.push(`| Metric | Count |`);
+  lines.push(`| --- | --- |`);
+  lines.push(`| Total issues | ${summary.totalIssues} |`);
+  lines.push(`| Critical | ${summary.critical} |`);
+  lines.push(`| Warnings | ${summary.warning} |`);
+  lines.push(`| Geometry | ${summary.byCategory.geometry} |`);
+  lines.push(`| Attribute | ${summary.byCategory.attribute} |`);
+  lines.push(`| Topology | ${summary.byCategory.topology} |`);
+  lines.push("");
+
+  const corrections = validation.corrections ?? [];
+  lines.push(`## Corrections`);
+  lines.push("");
+  lines.push(`Suggested corrections: ${corrections.length}`);
+  if (correction_decisions && Object.keys(correction_decisions).length > 0) {
+    lines.push("");
+    lines.push(`| Issue index | Decision | Custom override |`);
+    lines.push(`| --- | --- | --- |`);
+    for (const [idx, entry] of Object.entries(correction_decisions)) {
+      lines.push(
+        `| ${idx} | ${entry.decision} | ${entry.hasOverride ? "yes" : "no"} |`,
+      );
+    }
+  }
+  lines.push("");
+
+  const issues = validation.issues;
+  const shown = issues.slice(0, APPENDIX_ISSUE_LIMIT);
+  lines.push(`## Issues (${shown.length}${issues.length > shown.length ? ` of ${issues.length}` : ""})`);
+  lines.push("");
+  lines.push(`| # | Type | Severity | Feature | Description |`);
+  lines.push(`| --- | --- | --- | --- | --- |`);
+  for (let i = 0; i < shown.length; i++) {
+    const issue = shown[i];
+    const fid =
+      issue.feature_id !== undefined && issue.feature_id !== null
+        ? String(issue.feature_id)
+        : "—";
+    const desc = (issue.description ?? "").replace(/\|/g, "\\|").slice(0, 120);
+    lines.push(`| ${i} | ${issue.type} | ${issue.severity} | ${fid} | ${desc} |`);
+  }
+  if (issues.length > shown.length) {
+    lines.push("");
+    lines.push(`_…and ${issues.length - shown.length} more issues not listed._`);
+  }
+
+  return lines.join("\n");
+}
+
+export function downloadMarkdown(payload: QualityReportPayload, filenameBase: string): void {
+  const name = `${safeFilename(filenameBase)}-report.md`;
+  const blob = new Blob([renderReportMarkdown(payload)], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function printReport(): void {
+  window.print();
+}

--- a/frontend/src/utils/reportSummary.ts
+++ b/frontend/src/utils/reportSummary.ts
@@ -1,0 +1,119 @@
+import type {
+  CorrectionDecision,
+  CorrectionOverride,
+  GeometryIssue,
+  UploadResponse,
+  ValidationConfigResponse,
+  ValidationResult,
+} from "../types/api";
+
+export type IssueCategory = "geometry" | "attribute" | "topology";
+
+export function categorizeIssueType(type: string): IssueCategory {
+  if (type.startsWith("attribute_")) return "attribute";
+  if (type.startsWith("topology_")) return "topology";
+  return "geometry";
+}
+
+export type IssueSummary = {
+  totalIssues: number;
+  critical: number;
+  warning: number;
+  byCategory: Record<IssueCategory, number>;
+  byType: Record<string, number>;
+};
+
+export function computeIssueSummary(issues: GeometryIssue[]): IssueSummary {
+  const byCategory: Record<IssueCategory, number> = {
+    geometry: 0,
+    attribute: 0,
+    topology: 0,
+  };
+  const byType: Record<string, number> = {};
+
+  let critical = 0;
+  let warning = 0;
+
+  for (const issue of issues) {
+    const sev = (issue.severity || "").toLowerCase();
+    if (sev === "critical") critical += 1;
+    else if (sev === "warning") warning += 1;
+
+    const cat = categorizeIssueType(issue.type || "");
+    byCategory[cat] += 1;
+
+    const t = issue.type || "unknown";
+    byType[t] = (byType[t] ?? 0) + 1;
+  }
+
+  return {
+    totalIssues: issues.length,
+    critical,
+    warning,
+    byCategory,
+    byType,
+  };
+}
+
+export type CorrectionDecisionsSnapshot = Record<
+  string,
+  { decision: CorrectionDecision; hasOverride?: boolean }
+>;
+
+export type QualityReportPayload = {
+  generated_at: string;
+  dataset: UploadResponse;
+  validation: ValidationResult;
+  summary: IssueSummary;
+  correction_decisions?: CorrectionDecisionsSnapshot;
+  validation_config?: ValidationConfigResponse | null;
+};
+
+const DEFAULT_VALIDATION_CONFIG: ValidationConfigResponse = {
+  pipeline_steps: [
+    "geometry_validation",
+    "attribute_validation",
+    "topology_validation",
+    "generate_recommendations",
+  ],
+  geometry_validation_enabled: true,
+  attribute_sample_size: 500,
+  attribute_max_records_in_prompt: 10,
+  openai_model: "gpt-4o-mini",
+  topology_checks: { gaps: true, overlaps: true, connectivity: true },
+};
+
+export function buildQualityReportPayload(
+  dataset: UploadResponse,
+  validation: ValidationResult,
+  options?: {
+    correctionDecisions?: Record<number, CorrectionDecision>;
+    correctionOverrides?: Record<number, CorrectionOverride>;
+    validationConfig?: ValidationConfigResponse | null;
+    generatedAt?: string;
+  },
+): QualityReportPayload {
+  const correction_decisions: CorrectionDecisionsSnapshot | undefined =
+    options?.correctionDecisions && Object.keys(options.correctionDecisions).length > 0
+      ? Object.fromEntries(
+          Object.entries(options.correctionDecisions).map(([idx, decision]) => [
+            idx,
+            {
+              decision,
+              hasOverride: Boolean(options.correctionOverrides?.[Number(idx)]),
+            },
+          ]),
+        )
+      : undefined;
+
+  return {
+    generated_at: options?.generatedAt ?? new Date().toISOString(),
+    dataset,
+    validation,
+    summary: computeIssueSummary(validation.issues),
+    correction_decisions,
+    validation_config: options?.validationConfig ?? DEFAULT_VALIDATION_CONFIG,
+  };
+}
+
+export const APPENDIX_ISSUE_LIMIT = 500;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,4 +25,14 @@ export default defineConfig({
       },
     },
   },
+  preview: {
+    port: 4173,
+    host: "127.0.0.1",
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Add QualityReport component with summary stats, issue breakdown, CSS charts, and issue appendix
- Export reports as JSON, Markdown, and print-to-PDF from the Report page
- Add GET /api/v1/validation/config and POST /api/v1/reports/export for server-side config and exports
- Wire /report route, nav link, and dashboard View report shortcut
- Add Playwright E2E tests for report empty states, full UI flow, and export APIs

Closes #12

## Test plan
- [x] \cd backend && pytest tests/test_report.py -q\
- [x] \cd frontend && npm run build\
- [x] \cd frontend && npm run test:e2e\
- [ ] Manual: upload sample.geojson, validate, open Report, export JSON/Markdown, print to PDF