### PR TITLE
feat(#116): explain why Apply corrections is disabled

### DIFF
--- a/frontend/e2e/dashboard-apply.spec.ts
+++ b/frontend/e2e/dashboard-apply.spec.ts
@@ -1,0 +1,116 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sampleGeojson = path.resolve(__dirname, "../../backend/resources/sample.geojson");
+
+const MOCK_JOB_ID = "e2e-mock-validation-job-apply";
+
+function mockValidationSuccess(page: Page) {
+  let capturedDatasetId = "";
+
+  page.route("**/api/v1/validate/async", async (route) => {
+    const body = route.request().postDataJSON() as { dataset_id: string };
+    capturedDatasetId = body.dataset_id;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: MOCK_JOB_ID,
+        dataset_id: capturedDatasetId,
+        status: "pending",
+        error: null,
+        result: null,
+      }),
+    });
+  });
+
+  page.route(`**/api/v1/validate/jobs/${MOCK_JOB_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: MOCK_JOB_ID,
+        dataset_id: capturedDatasetId,
+        status: "completed",
+        error: null,
+        result: {
+          dataset_id: capturedDatasetId,
+          issues: [
+            {
+              feature_id: 1,
+              type: "invalid_geometry",
+              severity: "critical",
+              description: "E2E mock geometry issue",
+            },
+          ],
+          corrections: [
+            {
+              method: "buffer(0)",
+              confidence: 0.9,
+              explanation: "Fix invalid polygon",
+              issue_index: 0,
+            },
+          ],
+        },
+      }),
+    });
+  });
+}
+
+async function uploadDataset(page: Page) {
+  await page.goto("/#/upload");
+  await page.locator('input[type="file"]').setInputFiles(sampleGeojson);
+  await expect(page.getByText(/Loaded:\s*sample\.geojson/i)).toBeVisible({ timeout: 30_000 });
+}
+
+function applyCorrectionsButton(page: Page) {
+  return page.getByRole("button", { name: /Apply correction choices to the server/i });
+}
+
+test.describe("Apply corrections disabled hints (issue #116)", () => {
+  test("shows hint to run validation before validation has run", async ({ page }) => {
+    await uploadDataset(page);
+    await page.goto("/#/dashboard");
+
+    await expect(page.getByText(/Run validation to load issues and correction suggestions/i)).toBeVisible();
+    await expect(applyCorrectionsButton(page)).toBeDisabled();
+  });
+
+  test("shows hint to approve or reject when validated with no decisions", async ({ page }) => {
+    mockValidationSuccess(page);
+    await uploadDataset(page);
+    await page.goto("/#/dashboard");
+    await page.getByRole("button", { name: /^Run validation$/i }).click();
+    await expect(page.getByText(/Validation in progress/i)).toBeHidden({ timeout: 30_000 });
+    await expect(page.getByRole("button", { name: /Open quality report/i })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await expect(
+      page.getByText(/Approve or reject at least one suggested correction in Issue details/i),
+    ).toBeVisible();
+    await expect(applyCorrectionsButton(page)).toBeDisabled();
+  });
+
+  test("shows pending custom hint when Custom is chosen but not saved", async ({ page }) => {
+    mockValidationSuccess(page);
+    await uploadDataset(page);
+    await page.goto("/#/dashboard");
+    await page.getByRole("button", { name: /^Run validation$/i }).click();
+    await expect(page.getByText(/Validation in progress/i)).toBeHidden({ timeout: 30_000 });
+    await expect(page.getByRole("button", { name: /Open quality report/i })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.locator(".issues-panel-item").first().click();
+    await expect(page.getByRole("button", { name: /Use a custom fix you will edit before apply/i })).toBeVisible();
+    await page.getByRole("button", { name: /Use a custom fix you will edit before apply/i }).click();
+
+    await expect(
+      page.getByText(/Save custom fixes for all Custom issues before applying corrections/i),
+    ).toBeVisible();
+    await expect(applyCorrectionsButton(page)).toBeDisabled();
+  });
+});

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -15,8 +15,8 @@ import { DetailView } from "./DetailView";
 import { ApplyResultsPanel } from "./ApplyResultsPanel";
 import { useApp } from "../../context/AppContext";
 import {
-  buildApplyCorrectionsActions,
-  hasPendingCustomCorrections,
+  canApplyCorrections,
+  getApplyCorrectionsDisabledReasons,
 } from "../../utils/buildApplyCorrectionsRequest";
 
 export function DashboardPage() {
@@ -44,24 +44,25 @@ export function DashboardPage() {
   const totalFeatures =
     typeof currentDataset?.feature_count === "number" ? currentDataset.feature_count : null;
 
-  const applyActionsCount = useMemo(() => {
-    if (!validationResult) return 0;
-    return buildApplyCorrectionsActions(
+  const applyEligibility = useMemo(
+    () => ({
+      hasDataset: Boolean(currentDataset?.dataset_id),
       validationResult,
       correctionDecisions,
       correctionOverrides,
-    ).length;
-  }, [validationResult, correctionDecisions, correctionOverrides]);
-
-  const pendingCustomEdits = useMemo(
-    () => hasPendingCustomCorrections(correctionDecisions, correctionOverrides),
-    [correctionDecisions, correctionOverrides],
+    }),
+    [currentDataset?.dataset_id, validationResult, correctionDecisions, correctionOverrides],
   );
 
-  const canApplyCorrections =
-    Boolean(
-      currentDataset?.dataset_id && validationResult && applyActionsCount > 0 && !pendingCustomEdits,
-    );
+  const applyEnabled = useMemo(() => canApplyCorrections(applyEligibility), [applyEligibility]);
+
+  const applyDisabledReasons = useMemo(
+    () => getApplyCorrectionsDisabledReasons(applyEligibility),
+    [applyEligibility],
+  );
+
+  const showApplyDisabledHints =
+    !applyEnabled && !isValidating && !isApplyingCorrections && applyDisabledReasons.length > 0;
 
   const validateWillClearFeedback =
     Object.keys(correctionDecisions).length > 0 || lastApplyCorrectionsResult !== null;
@@ -135,8 +136,9 @@ export function DashboardPage() {
             <CalciteButton
               kind="neutral"
               onClick={handleApplyCorrections}
-              disabled={!canApplyCorrections || isValidating || isApplyingCorrections}
+              disabled={!applyEnabled || isValidating || isApplyingCorrections}
               loading={isApplyingCorrections}
+              aria-describedby={showApplyDisabledHints ? "apply-corrections-hint" : undefined}
               label={
                 isApplyingCorrections
                   ? "Applying corrections…"
@@ -145,16 +147,32 @@ export function DashboardPage() {
             >
               {isApplyingCorrections ? "Applying…" : "Apply corrections"}
             </CalciteButton>
+            {showApplyDisabledHints && (
+              <div
+                id="apply-corrections-hint"
+                className="dashboard-apply-hints-block"
+                role="status"
+                aria-live="polite"
+              >
+                {applyDisabledReasons.length === 1 ? (
+                  <p className="dashboard-validation-status">{applyDisabledReasons[0]}</p>
+                ) : (
+                  <>
+                    <p className="dashboard-validation-status">Apply corrections is disabled because:</p>
+                    <ul className="dashboard-apply-hints">
+                      {applyDisabledReasons.map((reason) => (
+                        <li key={reason}>{reason}</li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            )}
             {isValidating && (
               <div className="dashboard-validation-status" role="status" aria-live="polite">
                 <CalciteLoader scale="s" />
                 <span>Validation in progress. Issues and map will update when complete.</span>
               </div>
-            )}
-            {pendingCustomEdits && (
-              <p className="dashboard-validation-status" role="status">
-                Save custom fixes for all Custom issues before applying corrections.
-              </p>
             )}
             {isApplyingCorrections && (
               <div className="dashboard-validation-status" role="status" aria-live="polite">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -217,6 +217,23 @@ calcite-shell .app-main {
   flex-shrink: 0;
 }
 
+.dashboard-apply-hints-block {
+  flex: 1 1 100%;
+  min-width: min(100%, 22rem);
+}
+
+.dashboard-apply-hints-block .dashboard-validation-status {
+  margin: 0;
+}
+
+.dashboard-apply-hints {
+  margin: 0.35rem 0 0;
+  padding-left: 1.25rem;
+  font-size: 0.9rem;
+  color: #555;
+  line-height: 1.45;
+}
+
 .apply-results-panel {
   margin-bottom: 1rem;
 }

--- a/frontend/src/utils/buildApplyCorrectionsRequest.ts
+++ b/frontend/src/utils/buildApplyCorrectionsRequest.ts
@@ -60,3 +60,70 @@ export function hasPendingCustomCorrections(
     ([idx, decision]) => decision === "custom" && correctionOverrides[Number(idx)] === undefined,
   );
 }
+
+export type ApplyCorrectionsEligibilityInput = {
+  hasDataset: boolean;
+  validationResult: ValidationResult | null;
+  correctionDecisions: Record<number, CorrectionDecision>;
+  correctionOverrides: Record<number, CorrectionOverride>;
+};
+
+/** Whether the Apply corrections action can run with current UI state. */
+export function canApplyCorrections(input: ApplyCorrectionsEligibilityInput): boolean {
+  if (!input.hasDataset || !input.validationResult) return false;
+  if (hasPendingCustomCorrections(input.correctionDecisions, input.correctionOverrides)) {
+    return false;
+  }
+  return (
+    buildApplyCorrectionsActions(
+      input.validationResult,
+      input.correctionDecisions,
+      input.correctionOverrides,
+    ).length > 0
+  );
+}
+
+/** Human-readable reasons Apply corrections stays disabled (issue #116). */
+export function getApplyCorrectionsDisabledReasons(
+  input: ApplyCorrectionsEligibilityInput,
+): string[] {
+  if (!input.hasDataset) {
+    return ["Upload a dataset before applying corrections."];
+  }
+
+  if (!input.validationResult) {
+    return ["Run validation to load issues and correction suggestions."];
+  }
+
+  const reasons: string[] = [];
+  const suggestions = input.validationResult.corrections ?? [];
+  const withSuggestion = new Set(suggestions.map((c) => c.issue_index));
+  const actions = buildApplyCorrectionsActions(
+    input.validationResult,
+    input.correctionDecisions,
+    input.correctionOverrides,
+  );
+
+  if (hasPendingCustomCorrections(input.correctionDecisions, input.correctionOverrides)) {
+    reasons.push("Save custom fixes for all Custom issues before applying corrections.");
+  }
+
+  if (actions.length === 0) {
+    if (suggestions.length === 0) {
+      reasons.push("No correction suggestions are available for the current validation result.");
+    } else if (Object.keys(input.correctionDecisions).length === 0) {
+      reasons.push("Approve or reject at least one suggested correction in Issue details.");
+    } else {
+      const hasDecisionOnSuggestion = Object.entries(input.correctionDecisions).some(
+        ([idx]) => withSuggestion.has(Number(idx)),
+      );
+      if (!hasDecisionOnSuggestion) {
+        reasons.push(
+          "Choose Approve or Reject for an issue that has a correction suggestion.",
+        );
+      }
+    }
+  }
+
+  return reasons;
+}


### PR DESCRIPTION
## Summary
- Add centralized apply eligibility helpers and human-readable disabled reasons.
- Show inline dashboard hints when Apply corrections is disabled (validation, decisions, pending custom saves, etc.).
- Add Playwright e2e coverage for the three main hint scenarios.

Closes #116

## Test plan
- [x] `npm run build` in frontend
- [x] `npm run test:e2e -- dashboard-apply.spec.ts`
- [ ] Manual: approve one issue and confirm Apply enables and hints hide