### PR TITLE
feat(#115): empty dashboard onboarding hint with Upload link

### DIFF
--- a/frontend/e2e/dashboard-apply.spec.ts
+++ b/frontend/e2e/dashboard-apply.spec.ts
@@ -69,6 +69,17 @@ function applyCorrectionsButton(page: Page) {
   return page.getByRole("button", { name: /Apply correction choices to the server/i });
 }
 
+test("dashboard shows empty state with upload link before dataset loaded", async ({ page }) => {
+  await page.goto("/#/dashboard");
+  const dashboard = page.getByLabel("Validation dashboard");
+  await expect(page.getByRole("heading", { name: /Validation dashboard/i })).toBeVisible();
+  await expect(dashboard.getByText(/No dataset loaded/i)).toBeVisible();
+  const uploadLink = dashboard.getByRole("link", { name: "Upload" });
+  await expect(uploadLink).toBeVisible();
+  await uploadLink.click();
+  await expect(page).toHaveURL(/#\/upload/);
+});
+
 test.describe("Apply corrections disabled hints (issue #116)", () => {
   test("shows hint to run validation before validation has run", async ({ page }) => {
     await uploadDataset(page);

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   CalcitePanel,
   CalciteButton,
@@ -87,8 +87,8 @@ export function DashboardPage() {
       </h2>
       {!currentDataset ? (
         <p className="empty-state">
-          Upload and validate a dataset first. The dashboard will show issues, stats, and map view
-          once validation has run.
+          No dataset loaded. Upload a dataset on the <Link to="/upload">Upload</Link> page first,
+          then return here to run validation and view issues, stats, and the map.
         </p>
       ) : (
         <>


### PR DESCRIPTION
## Summary

- Add onboarding empty state on Dashboard when no dataset is loaded, with a link to the Upload page
- Clarify upload-first workflow (pilot finding Theme 3 from user testing)
- Align with existing Report page empty-state pattern

Closes #115

## Test plan

- [x] `npm run build` (frontend)
- [x] `npm run test:e2e -- dashboard-apply.spec.ts -g "empty state"`
- [ ] Manual: open `/#/dashboard` with no upload, click Upload link, confirm navigation to Upload page
