### PR TITLE
feat(#120): Map tab cross-link to Dashboard after validation

### DIFF
--- a/frontend/e2e/map-dashboard.spec.ts
+++ b/frontend/e2e/map-dashboard.spec.ts
@@ -70,10 +70,11 @@ test("map page links to dashboard after validation (issue #120)", async ({ page 
   await uploadDataset(page);
   await page.goto("/#/map");
 
-  await page
-    .getByRole("region", { name: "Validate dataset" })
-    .getByRole("button", { name: /^Validate dataset$/i })
-    .click();
+  const validateBlock = page.locator("calcite-block.map-validate-block");
+  await validateBlock.evaluate((el) => {
+    (el as HTMLElement & { expanded: boolean }).expanded = true;
+  });
+  await validateBlock.getByRole("button", { name: /^Validate dataset$/i }).last().click();
 
   const reviewButton = page.getByRole("button", { name: /Review issues on Dashboard/i });
   await expect(reviewButton).toBeVisible({ timeout: 30_000 });
@@ -81,5 +82,5 @@ test("map page links to dashboard after validation (issue #120)", async ({ page 
 
   await expect(page).toHaveURL(/#\/dashboard/);
   await expect(page.getByRole("heading", { name: /Validation dashboard/i })).toBeVisible();
-  await expect(page.getByRole("heading", { name: /Issues/i })).toBeVisible();
+  await expect(page.locator(".dashboard-panel--issues")).toBeVisible();
 });

--- a/frontend/e2e/map-dashboard.spec.ts
+++ b/frontend/e2e/map-dashboard.spec.ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sampleGeojson = path.resolve(__dirname, "../../backend/resources/sample.geojson");
+
+const MOCK_JOB_ID = "e2e-mock-validation-job-map-dashboard";
+
+function mockValidationSuccess(page: Page) {
+  let capturedDatasetId = "";
+
+  page.route("**/api/v1/validate/async", async (route) => {
+    const body = route.request().postDataJSON() as { dataset_id: string };
+    capturedDatasetId = body.dataset_id;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: MOCK_JOB_ID,
+        dataset_id: capturedDatasetId,
+        status: "pending",
+        error: null,
+        result: null,
+      }),
+    });
+  });
+
+  page.route(`**/api/v1/validate/jobs/${MOCK_JOB_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: MOCK_JOB_ID,
+        dataset_id: capturedDatasetId,
+        status: "completed",
+        error: null,
+        result: {
+          dataset_id: capturedDatasetId,
+          issues: [
+            {
+              feature_id: 1,
+              type: "invalid_geometry",
+              severity: "critical",
+              description: "E2E mock geometry issue",
+            },
+          ],
+          corrections: [
+            {
+              method: "buffer(0)",
+              confidence: 0.9,
+              explanation: "Fix invalid polygon",
+              issue_index: 0,
+            },
+          ],
+        },
+      }),
+    });
+  });
+}
+
+async function uploadDataset(page: Page) {
+  await page.goto("/#/upload");
+  await page.locator('input[type="file"]').setInputFiles(sampleGeojson);
+  await expect(page.getByText(/Loaded:\s*sample\.geojson/i)).toBeVisible({ timeout: 30_000 });
+}
+
+test("map page links to dashboard after validation (issue #120)", async ({ page }) => {
+  mockValidationSuccess(page);
+  await uploadDataset(page);
+  await page.goto("/#/map");
+
+  await page
+    .getByRole("region", { name: "Validate dataset" })
+    .getByRole("button", { name: /^Validate dataset$/i })
+    .click();
+
+  const reviewButton = page.getByRole("button", { name: /Review issues on Dashboard/i });
+  await expect(reviewButton).toBeVisible({ timeout: 30_000 });
+  await reviewButton.click();
+
+  await expect(page).toHaveURL(/#\/dashboard/);
+  await expect(page.getByRole("heading", { name: /Validation dashboard/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Issues/i })).toBeVisible();
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -380,6 +380,19 @@ calcite-shell .app-main {
   margin-top: 1rem;
 }
 
+.map-validate-block {
+  margin: 0 1rem;
+}
+
+.map-dashboard-cta {
+  margin: 0 1rem 1rem;
+  padding: 0 0 0.25rem;
+}
+
+.map-dashboard-cta .page-section-description {
+  margin-bottom: 0.75rem;
+}
+
 .validation-summary-inline {
   margin-top: 0.5rem;
 }

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,4 +1,5 @@
 import { CalciteBlock, CalciteButton } from "@esri/calcite-components-react";
+import { useNavigate } from "react-router-dom";
 import { MapViewer } from "../components/Map/MapViewer";
 import { useApp } from "../context/AppContext";
 
@@ -11,6 +12,7 @@ export function MapPage() {
     validationError,
     handleValidate,
   } = useApp();
+  const navigate = useNavigate();
 
   return (
     <section className="page-section page-section--map" aria-labelledby="map-heading">
@@ -54,6 +56,21 @@ export function MapPage() {
               </p>
             )}
           </CalciteBlock>
+          {validationResult ? (
+            <div className="map-dashboard-cta" role="region" aria-label="Review issues on Dashboard">
+              <p className="page-section-description">
+                Review issue details, filters, and correction choices on the Dashboard.
+              </p>
+              <CalciteButton
+                kind="brand"
+                appearance="outline"
+                onClick={() => navigate("/dashboard")}
+                label="Review issues on Dashboard"
+              >
+                Review issues on Dashboard
+              </CalciteButton>
+            </div>
+          ) : null}
           <MapViewer
             datasetId={currentDataset.dataset_id}
             bounds={currentDataset.bounds ?? null}


### PR DESCRIPTION
## Summary
- After validation completes on the Map tab, show a visible call-to-action to open the Dashboard for issue review, filters, and approve/reject decisions.
- Place the CTA outside the collapsible validate block so it stays visible when the block is collapsed.
- Add Playwright e2e coverage for validate-on-map → navigate to Dashboard.

## Test plan
- [x] `npm run test:e2e -- map-dashboard.spec.ts` (in frontend)
- [ ] Upload sample.geojson, validate on Map tab, click **Review issues on Dashboard**, confirm Dashboard loads with issues panel

Closes #120