### PR TITLE
feat(#118): highlight Approve/Reject on first correction suggestion

### DIFF
--- a/frontend/e2e/dashboard-apply.spec.ts
+++ b/frontend/e2e/dashboard-apply.spec.ts
@@ -114,3 +114,34 @@ test.describe("Apply corrections disabled hints (issue #116)", () => {
     await expect(applyCorrectionsButton(page)).toBeDisabled();
   });
 });
+
+async function runValidationOnDashboard(page: Page) {
+  await page.goto("/#/dashboard");
+  await page.getByRole("button", { name: /^Run validation$/i }).click();
+  await expect(page.getByText(/Validation in progress/i)).toBeHidden({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: /Open quality report/i })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test.describe("First correction callout (issue #118)", () => {
+  test("shows Approve/Reject callout on first issue with a suggestion", async ({ page }) => {
+    mockValidationSuccess(page);
+    await uploadDataset(page);
+    await runValidationOnDashboard(page);
+
+    await page.locator(".issues-panel-item").first().click();
+    await expect(page.getByText(/Choose Approve or Reject to record your decision/i)).toBeVisible();
+  });
+
+  test("hides callout after Approve is chosen", async ({ page }) => {
+    mockValidationSuccess(page);
+    await uploadDataset(page);
+    await runValidationOnDashboard(page);
+
+    await page.locator(".issues-panel-item").first().click();
+    await expect(page.getByText(/Choose Approve or Reject to record your decision/i)).toBeVisible();
+    await page.getByRole("button", { name: /Approve suggested fix/i }).click();
+    await expect(page.getByText(/Choose Approve or Reject to record your decision/i)).toBeHidden();
+  });
+});

--- a/frontend/src/components/Dashboard/DetailView.tsx
+++ b/frontend/src/components/Dashboard/DetailView.tsx
@@ -1,16 +1,30 @@
-import { useMemo, useState } from "react";
-import { CalciteButton, CalciteDialog } from "@esri/calcite-components-react";
+import { useEffect, useMemo, useState } from "react";
+import { CalciteButton, CalciteDialog, CalciteNotice } from "@esri/calcite-components-react";
 
 import { useApp } from "../../context/AppContext";
-import type { CorrectionSuggestion, GeometryIssue } from "../../types/api";
+import type { CorrectionDecision, CorrectionSuggestion, GeometryIssue } from "../../types/api";
+import { getFirstCorrectionIssueIndex } from "../../utils/correctionSuggestions";
 import { CustomCorrectionEditor } from "./CustomCorrectionEditor";
 
 export type DetailViewProps = {
   selectedIssueIndex: number | null;
 };
 
+function validationCalloutKey(
+  datasetId: string | undefined,
+  corrections: { issue_index: number }[] | null | undefined,
+): string {
+  const indices = (corrections ?? [])
+    .map((c) => c.issue_index)
+    .filter((i) => typeof i === "number")
+    .sort((a, b) => a - b)
+    .join(",");
+  return `${datasetId ?? ""}:${indices}`;
+}
+
 export function DetailView({ selectedIssueIndex }: DetailViewProps) {
   const [resetAllConfirmOpen, setResetAllConfirmOpen] = useState(false);
+  const [calloutDismissed, setCalloutDismissed] = useState(false);
   const {
     validationResult,
     currentDataset,
@@ -23,6 +37,15 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
     resetCorrectionDecisions,
     isApplyingCorrections,
   } = useApp();
+
+  const calloutResetKey = validationCalloutKey(
+    validationResult?.dataset_id,
+    validationResult?.corrections,
+  );
+
+  useEffect(() => {
+    setCalloutDismissed(false);
+  }, [calloutResetKey]);
 
   const issue: GeometryIssue | null =
     selectedIssueIndex !== null && validationResult?.issues?.[selectedIssueIndex]
@@ -38,6 +61,15 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
     );
   }, [selectedIssueIndex, validationResult?.corrections]);
 
+  const firstCorrectionIssueIndex = useMemo(
+    () =>
+      getFirstCorrectionIssueIndex(
+        validationResult?.corrections,
+        validationResult?.issues?.length ?? 0,
+      ),
+    [validationResult?.corrections, validationResult?.issues?.length],
+  );
+
   const hasAnyDecisions = Object.keys(correctionDecisions).length > 0;
 
   if (!issue || selectedIssueIndex === null) {
@@ -46,6 +78,20 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
 
   const issueIndex = selectedIssueIndex;
   const decision = correctionDecisions[issueIndex];
+
+  const showApproveRejectCallout =
+    Boolean(suggestion) &&
+    firstCorrectionIssueIndex !== null &&
+    issueIndex === firstCorrectionIssueIndex &&
+    decision === undefined &&
+    !calloutDismissed;
+
+  function handleCorrectionDecision(choice: CorrectionDecision) {
+    if (choice === "approve" || choice === "reject") {
+      setCalloutDismissed(true);
+    }
+    setCorrectionDecision(issueIndex, choice);
+  }
 
   return (
     <div className="detail-view">
@@ -120,15 +166,36 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
               <strong>Explanation:</strong> {suggestion.explanation}
             </p>
 
-            <div className="correction-actions" role="group" aria-labelledby="correction-actions-label">
+            <div
+              className={`correction-actions${showApproveRejectCallout ? " correction-actions--onboarding" : ""}`}
+              role="group"
+              aria-labelledby="correction-actions-label"
+            >
               <p id="correction-actions-label" className="correction-actions__label">
                 How should we handle this suggestion?
               </p>
+              {showApproveRejectCallout && (
+                <CalciteNotice
+                  open
+                  kind="info"
+                  icon
+                  scale="s"
+                  width="full"
+                  closable
+                  className="correction-callout"
+                  onCalciteNoticeClose={() => setCalloutDismissed(true)}
+                >
+                  <div slot="message">
+                    Choose <strong>Approve</strong> or <strong>Reject</strong> to record your decision. You need at
+                    least one choice before <strong>Apply corrections</strong> is enabled.
+                  </div>
+                </CalciteNotice>
+              )}
               <div className="correction-actions__buttons">
                 <CalciteButton
                   kind={decision === "approve" ? "brand" : "neutral"}
                   appearance={decision === "approve" ? "solid" : "outline"}
-                  onClick={() => setCorrectionDecision(issueIndex, "approve")}
+                  onClick={() => handleCorrectionDecision("approve")}
                   disabled={isApplyingCorrections}
                   label="Approve suggested fix"
                 >
@@ -137,7 +204,7 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
                 <CalciteButton
                   kind={decision === "reject" ? "brand" : "neutral"}
                   appearance={decision === "reject" ? "solid" : "outline"}
-                  onClick={() => setCorrectionDecision(issueIndex, "reject")}
+                  onClick={() => handleCorrectionDecision("reject")}
                   disabled={isApplyingCorrections}
                   label="Reject suggested fix"
                 >
@@ -146,7 +213,7 @@ export function DetailView({ selectedIssueIndex }: DetailViewProps) {
                 <CalciteButton
                   kind={decision === "custom" ? "brand" : "neutral"}
                   appearance={decision === "custom" ? "solid" : "outline"}
-                  onClick={() => setCorrectionDecision(issueIndex, "custom")}
+                  onClick={() => handleCorrectionDecision("custom")}
                   disabled={isApplyingCorrections}
                   label="Use a custom fix you will edit before apply"
                 >

--- a/frontend/src/components/Dashboard/IssuesPanel.tsx
+++ b/frontend/src/components/Dashboard/IssuesPanel.tsx
@@ -8,6 +8,7 @@ import {
 
 import type { CorrectionDecision, GeometryIssue } from "../../types/api";
 import { useApp } from "../../context/AppContext";
+import { correctionIndicesFromIssues } from "../../utils/correctionSuggestions";
 import { categorizeIssueType } from "../../utils/reportSummary";
 
 export type IssuesPanelProps = {
@@ -17,24 +18,6 @@ export type IssuesPanelProps = {
 
 type TypeFilter = "all" | "geometry" | "attribute" | "topology";
 type SeverityFilter = "all" | "critical" | "warning";
-
-function correctionIndicesFromIssues(
-  issues: GeometryIssue[],
-  corrections: { issue_index: number }[] | null | undefined,
-): Set<number> {
-  const withSuggestion = new Set<number>();
-  if (!corrections?.length) return withSuggestion;
-  for (const c of corrections) {
-    if (
-      typeof c.issue_index === "number" &&
-      c.issue_index >= 0 &&
-      c.issue_index < issues.length
-    ) {
-      withSuggestion.add(c.issue_index);
-    }
-  }
-  return withSuggestion;
-}
 
 function decisionShortLabel(d: CorrectionDecision): string {
   if (d === "approve") return "A";
@@ -46,8 +29,8 @@ export function IssuesPanel({ issues, onSelectIssueIndex }: IssuesPanelProps) {
   const { validationResult, correctionDecisions, correctionOverrides } = useApp();
 
   const indicesWithCorrection = useMemo(
-    () => correctionIndicesFromIssues(issues, validationResult?.corrections),
-    [issues, validationResult?.corrections],
+    () => correctionIndicesFromIssues(issues.length, validationResult?.corrections),
+    [issues.length, validationResult?.corrections],
   );
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -444,6 +444,17 @@ calcite-shell .app-main {
   font-weight: 600;
 }
 
+.correction-callout {
+  margin-bottom: 0.75rem;
+}
+
+.correction-actions--onboarding .correction-actions__buttons {
+  padding: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px rgba(0, 121, 193, 0.25);
+  background: rgba(0, 121, 193, 0.04);
+}
+
 .correction-actions__buttons {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/utils/correctionSuggestions.ts
+++ b/frontend/src/utils/correctionSuggestions.ts
@@ -1,0 +1,26 @@
+export function correctionIndicesFromIssues(
+  issuesLength: number,
+  corrections: { issue_index: number }[] | null | undefined,
+): Set<number> {
+  const withSuggestion = new Set<number>();
+  if (!corrections?.length) return withSuggestion;
+  for (const c of corrections) {
+    if (
+      typeof c.issue_index === "number" &&
+      c.issue_index >= 0 &&
+      c.issue_index < issuesLength
+    ) {
+      withSuggestion.add(c.issue_index);
+    }
+  }
+  return withSuggestion;
+}
+
+export function getFirstCorrectionIssueIndex(
+  corrections: { issue_index: number }[] | null | undefined,
+  issuesLength: number,
+): number | null {
+  const indices = correctionIndicesFromIssues(issuesLength, corrections);
+  if (indices.size === 0) return null;
+  return Math.min(...indices);
+}


### PR DESCRIPTION
## Summary
- Add a subtle onboarding callout in Issue details when the user views the first issue with a correction suggestion
- Guide users to choose Approve or Reject before Apply corrections is enabled (complements #116)
- Extract shared correction index helpers into `correctionSuggestions.ts`

## Test plan
- [x] `npm run build` (frontend)
- [x] `npm run test:e2e -- dashboard-apply.spec.ts` (5 tests; one upload step can flake under load)
- [ ] Manual: validate sample dataset, select first issue with Fix badge, confirm callout and button highlight, Approve dismisses callout

Closes #118