### PR TITLE
fix: coerce numpy feature_id to native types for JSON serialization

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,7 +1,20 @@
 """Pydantic schemas for API request/response."""
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+def _to_native(value: Any) -> Any:
+    """Coerce numpy scalars (e.g. int32 from shapefile/GeoJSON id columns) to native
+    Python types so Pydantic can JSON-serialize them. Leaves other values untouched."""
+    item = getattr(value, "item", None)
+    if callable(item) and getattr(value, "ndim", None) == 0:
+        # numpy scalar: 0-dim array-like with .item()
+        try:
+            return value.item()
+        except Exception:
+            return value
+    return value
 
 
 class GeometryIssue(BaseModel):
@@ -12,6 +25,11 @@ class GeometryIssue(BaseModel):
     severity: str = Field(..., description="critical or warning")
     location: Optional[List[float]] = Field(None, description="[x, y] for map display")
     description: Optional[str] = Field(None, description="Human-readable reason")
+
+    @field_validator("feature_id", mode="before")
+    @classmethod
+    def _coerce_feature_id(cls, v: Any) -> Any:
+        return _to_native(v)
 
 
 # Error codes for consistent API error responses

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,40 @@
+"""Tests for api.models serialization edge cases."""
+import numpy as np
+import pytest
+
+# Backend on path via conftest
+from api.models import GeometryIssue, ValidationResult
+
+
+@pytest.mark.parametrize(
+    "value, expected_type",
+    [
+        (np.int32(10), int),
+        (np.int64(11), int),
+        (np.float32(3.5), float),
+        (np.float64(2.0), float),
+        (7, int),
+        ("abc", str),
+        (None, type(None)),
+    ],
+)
+def test_feature_id_coerced_to_native(value, expected_type):
+    """Numpy scalars (e.g. int32 from shapefile id columns) coerce to native
+    Python types so Pydantic can JSON-serialize them (regression for
+    PydanticSerializationError: numpy.int32)."""
+    issue = GeometryIssue(feature_id=value, type="topology_overlap", severity="warning")
+    assert type(issue.feature_id) is expected_type
+
+
+def test_validation_result_serializes_numpy_feature_id():
+    """ValidationResult with a numpy feature_id serializes to JSON without error."""
+    issue = GeometryIssue(
+        feature_id=np.int32(10),
+        type="topology_overlap",
+        severity="warning",
+        location=[1.5, 1.5],
+        description="Overlap with feature 11",
+    )
+    result = ValidationResult(dataset_id="x", issues=[issue])
+    payload = result.model_dump_json()
+    assert '"feature_id":10' in payload


### PR DESCRIPTION
## What changed

Added a Pydantic `field_validator` on `GeometryIssue.feature_id` (in `backend/api/models.py`) that coerces numpy scalar types to native Python types. Added regression tests in `backend/tests/test_models.py`.

## Why

`GeometryIssue.feature_id` is typed `Any`. When a dataset has an integer `id` column — common from shapefile `.dbf` files or GeoJSON integer properties — GeoPandas exposes those values as numpy scalars (`int32`/`int64`). Pydantic v2 cannot JSON-serialize numpy types, so serializing a `ValidationResult` (e.g. on a validation job-status poll) raised:

```
PydanticSerializationError: Unable to serialize unknown type: <class numpy.int32>
```

`core/validation.py` happened to coerce its feature_id to native `int`, but the **topology** path (`core/topology.py` `_get_feature_id`) and the **attribute** path (`services/attribute_extractor.py`) passed numpy values through unchanged.

## Approach

Rather than patch each producer, the fix lives at the single point all validation paths converge — the `GeometryIssue` model — so it covers geometry, topology, and attribute issues at once. Native types, strings, and `None` are left untouched.

## Testing

- Reproduced the exact error first via the topology path with an `int32` `id` column.
- Verified the fix serializes correctly for `int32`, `int64`, `float32`, `float64`, `int`, `str`, and `None`.
- Added 8 regression tests in `backend/tests/test_models.py`.
- Full backend suite: **93 passed** (85 existing + 8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
