### PR TITLE
Fix OPENAI_API_KEY not passed to ChatOpenAI (validate 500)

### DIFF
--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -60,15 +60,28 @@ def _default_llm(config: Optional[AttributeValidationConfig] = None) -> Supports
     Construct a default ChatOpenAI client.
 
     Uses OPENAI_API_KEY / OPENAI_MODEL from core.config. Tests should inject a fake llm instead.
-    Raises RuntimeError if langchain_openai is not installed.
+    Raises RuntimeError if langchain_openai is not installed or no API key is configured.
+
+    Note: the API key is read from settings.OPENAI_API_KEY (i.e. the backend .env loaded by
+    pydantic-settings) and passed explicitly, so it works without OPENAI_API_KEY also being
+    set as an OS environment variable.
     """
     if ChatOpenAI is None:
         raise RuntimeError(
             "langchain_openai is not installed. Install backend requirements or "
             "pass an explicit `llm` instance to validate_attributes_with_llm."
         )
+    if not settings.OPENAI_API_KEY:
+        raise RuntimeError(
+            "OPENAI_API_KEY is not configured. Set it in the backend .env or pass an "
+            "explicit `llm` instance."
+        )
     cfg = config or AttributeValidationConfig()
-    return ChatOpenAI(model=cfg.model, max_tokens=cfg.max_tokens)  # type: ignore[call-arg]
+    return ChatOpenAI(  # type: ignore[call-arg]
+        model=cfg.model,
+        max_tokens=cfg.max_tokens,
+        api_key=settings.OPENAI_API_KEY,
+    )
 
 
 def build_attribute_validation_prompt(
@@ -215,10 +228,12 @@ def validate_attributes_with_llm(
         return []
 
     prompt = build_attribute_validation_prompt(attribute_records, per_field_values)
-    client = llm or _default_llm(config)
     try:
+        client = llm or _default_llm(config)
         response = client.invoke(prompt)
     except Exception:
+        # Fail-safe: missing/invalid credentials or API errors yield no issues
+        # rather than failing the whole validation pipeline.
         return []
 
     return parse_llm_attribute_issues(response)
@@ -321,10 +336,12 @@ def get_recommendation_suggestions_from_llm(
     prompt = build_recommendation_prompt(issues)
     if not prompt:
         return []
-    client = llm or _default_llm()
     try:
+        client = llm or _default_llm()
         response = client.invoke(prompt)
     except Exception:
+        # Fail-safe: fall back to rule-based suggestions (caller pads with defaults)
+        # when credentials are missing or the API call fails.
         return []
     parsed = parse_recommendation_suggestions(response)
     # Pad to match issue count if LLM returned fewer

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -115,6 +115,31 @@ def test_validate_attributes_with_llm_empty_input_returns_empty_and_skips_llm():
     assert llm.last_prompt is None
 
 
+def test_validate_attributes_with_llm_no_api_key_degrades_gracefully(monkeypatch):
+    """Without an API key and no injected LLM, return [] instead of raising.
+
+    Regression: _default_llm() used to raise during client construction outside the
+    try/except, which surfaced as a 500 from POST /validate.
+    """
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", None, raising=False)
+    records: List[Dict[str, Any]] = [{"feature_id": 1, "name": "Main St"}]
+
+    # No llm injected and no key configured -> graceful empty result, no exception.
+    assert validate_attributes_with_llm(records) == []
+
+
+def test_default_llm_raises_without_api_key(monkeypatch):
+    """_default_llm should raise (not silently build a keyless client) when no key is set."""
+    from core.config import settings
+    from services.llm_service import _default_llm
+
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", None, raising=False)
+    with pytest.raises(RuntimeError):
+        _default_llm()
+
+
 # --- Recommendation suggestions (issue #87) ---
 
 


### PR DESCRIPTION
## Problem
`POST /api/v1/validate` returned **500 Internal Server Error** when running the backend normally (`uvicorn main:app`), even with a valid `OPENAI_API_KEY` set in `backend/.env`.

Root cause: in `services/llm_service.py`, `_default_llm()` constructed `ChatOpenAI(model=..., max_tokens=...)` **without passing `api_key`**. The key loaded from `.env` by pydantic-settings lives on `settings.OPENAI_API_KEY`, but `ChatOpenAI` only falls back to the `OPENAI_API_KEY` **OS environment variable** — which isn't set just because the value is in `.env`. So client construction raised `OpenAIError: Missing credentials`. That construction happened *outside* the `try/except`, so the error propagated as a 500 instead of degrading.

## Fix
- Pass `api_key=settings.OPENAI_API_KEY` explicitly to `ChatOpenAI`, so the `.env` value is actually used (no need to also export the variable).
- Raise a clear `RuntimeError` from `_default_llm()` when no key is configured.
- Move client construction *inside* the `try/except` in `validate_attributes_with_llm()` and `get_recommendation_suggestions_from_llm()`, so a missing/invalid key (or any API error) **degrades to no LLM issues** — geometry/topology validation and rule-based recommendations still run — instead of failing the whole pipeline.

## Tests
- New regression tests: the no-key path returns `[]` without raising, and `_default_llm()` raises without a key.
- Full backend suite: **95 passed**.
- Verified live: a plain `uvicorn main:app` (key only in `.env`, **not** exported) now returns **200** from `/validate` with LLM attribute issues present.

## Notes
Follow-up to #127 (which fixed the frontend dev server and polished the UI). This is backend-only and touches no API shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)